### PR TITLE
Add system.indices

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -199,6 +199,17 @@ proc low*[T](x: T): T {.magic: "Low", noSideEffect.}
   ## the lowest possible value of an ordinal value `x`. As a special
   ## semantic rule, `x` may also be a type identifier.
 
+template indices*(x): expr = low(x) .. high(x)
+  ## iterate over any value for which `low` and `high` are defined. Can be used
+  ## for compact loops, similar to `items` and `pairs`, as well as to construct
+  ## ranges:
+  ##
+  ## .. code-block:: Nim
+  ##   var x = @[2,3,5,7,11]
+  ##   for i in indices(x):
+  ##     echo i
+  ##   let r = indices(x)
+
 type
   range*{.magic: "Range".}[T] ## Generic type to construct range types.
   array*{.magic: "Array".}[I, T]  ## Generic type to construct

--- a/tests/stdlib/tindices.nim
+++ b/tests/stdlib/tindices.nim
@@ -1,0 +1,36 @@
+discard """
+  output: '''0 1 2 3 4 (a: 0, b: 4)
+0 1 2 3 4 (a: 0, b: 4)
+a b c d e (a: a, b: e)
+0 1 2 3 4 (a: 0, b: 4)'''
+"""
+
+import sequtils
+
+block:
+  var x = @[12.0, 15.6, 19.0, 25, 23.9]
+  for i in x.indices:
+    stdout.write i, " "
+  stdout.write indices(x), " "
+  echo toSeq(indices(x))
+
+block:
+  var x = [12.0, 15.6, 19.0, 25, 23.9]
+  for i in x.indices:
+    stdout.write i, " "
+  stdout.write indices(x), " "
+  echo toSeq(indices(x))
+
+block:
+  var x: array['a'..'e', float] = [12.0, 15.6, 19.0, 25, 23.9]
+  for i in x.indices:
+    stdout.write i, " "
+  stdout.write indices(x), " "
+  echo toSeq(indices(x))
+
+block:
+  var x = "fooba"
+  for i in x.indices:
+    stdout.write i, " "
+  stdout.write indices(x), " "
+  echo toSeq(indices(x))


### PR DESCRIPTION
I find this useful since I often iterate from low to high, but don't want to use `for index, value in list` when I don't need the value.

The template is pretty simple:
```nimrod
template indices*(x): expr = low(x) .. high(x)
```

I'm not sure about the name. `range` would be perfect, but is taken already, `indices` (my favorite) is analog to `items` and `pairs`. Altenative choices are `span` and `space`.

This could be done with an iterator:
```nimrod
iterator indices(x) =
  for i in low(x) .. high(x):
    yield i
```
But then you can't create ranges:
```nimrod
var r = indices(x)
```

If you want to iterate over datatypes the values could be converted to `BiggestInteger` in the template, which I didn't do since `low` and `high` don't do that either.
