### PR TITLE
Add fractions library

### DIFF
--- a/lib/pure/fractions.nim
+++ b/lib/pure/fractions.nim
@@ -1,0 +1,62 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2015 Adel Qalieh
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+##   A man is like a fraction whose numerator is what he is and whose
+##   denominator is what he thinks of himself. The larger the denominator, the
+##   smaller the fraction. -- Leo Tolstoy
+## 
+## Rational number arithmetic for Nim.
+
+import math
+import unittest
+
+proc gcd*(a, b): int =
+  ## Greatest common divisor
+  var
+    a = a
+    b = b
+  while b != 0:
+    a = a mod b
+    swap a, b
+  return a
+
+type
+  Fraction* = object of RootObj
+    numerator*: int
+    denominator*: int
+
+proc newFraction(numerator: int, denominator: int): Fraction =
+  let g:int = gcd(numerator, denominator)
+  result.numerator = numerator div g
+  result.denominator = denominator div g
+
+proc `+` (a, b: Fraction): Fraction =
+  return newFraction(a.numerator * b.denominator +
+                     b.numerator * a.denominator,
+                     a.denominator * b.denominator)
+
+proc `-` (a, b: Fraction): Fraction =
+  return newFraction(a.numerator * b.denominator -
+                     b.numerator * a.denominator,
+                     a.denominator * b.denominator)
+
+proc `*` (a, b: Fraction): Fraction =
+  return newFraction(a.numerator * b.numerator, a.denominator * b.denominator)
+
+proc `/` (a, b: Fraction): Fraction =
+  return newFraction(a.numerator * b.denominator, a.denominator * b.numerator)
+
+proc floor(a: Fraction): Fraction =
+  return newFraction(a.numerator div a.denominator, 1)
+
+proc `div` (a, b: Fraction): Fraction =
+  return floor(a / b)
+
+proc `mod` (a, b: Fraction): Fraction =
+  return a - b * (a div b)

--- a/tests/stdlib/tfractions.nim
+++ b/tests/stdlib/tfractions.nim
@@ -1,0 +1,40 @@
+import fractions
+import unittest
+
+suite "fractions":
+  test "greatest common divisor":
+    check:
+      gcd(15, 18) == 3
+      gcd(0, 0) == 0
+      gcd(-3, 3) == 3
+
+  test "fractions reduced on creation":
+    check:
+      newFraction(10, -8).numerator == 5
+      newFraction(10, -8).denominator == -4
+
+  test "adding fractions":
+    check:
+      newFraction(2, 3) + newFraction(1, 3) == newFraction(3, 3)
+      newFraction(2, 3) + newFraction(1, 6) == newFraction(5, 6)
+
+  test "subtracting fractions":
+    check:
+      newFraction(2, 3) - newFraction(1, 3) == newFraction(1, 3)
+      newFraction(2, 3) - newFraction(1, 6) == newFraction(1, 2)
+
+  test "multiplying fractions":
+    check:
+      newFraction(2, 3) * newFraction(1, 3) == newFraction(2, 9)
+      newFraction(2, 3) * newFraction(1, 6) == newFraction(1, 9)
+
+  test "dividing fractions":
+    check:
+      newFraction(2, 3) / newFraction(1, 3) == newFraction(2, 1)
+      newFraction(2, 3) / newFraction(1, 6) == newFraction(4, 1)
+
+  test "modulo of fractions":
+    check:
+      newFraction(2, 3) mod newFraction(1, 3) == newFraction(0, 1)
+      newFraction(2, 3) mod newFraction(1, 6) == newFraction(0, 1)
+      newFraction(2, 3) mod newFraction(3, 6) == newFraction(1, 6)


### PR DESCRIPTION
Adds rational number arithmetic to the standard library. Inspired by Python's [`fractions`](https://docs.python.org/3/library/fractions.html) module in the standard library.