### PR TITLE
Allow higher versions of libmysqlclient

### DIFF
--- a/lib/wrappers/mysql.nim
+++ b/lib/wrappers/mysql.nim
@@ -12,7 +12,7 @@
 
 when defined(Unix): 
   const 
-    lib = "libmysqlclient.so.15"
+    lib = "libmysqlclient.so.(15|16|17|18)"
 when defined(Windows): 
   const 
     lib = "libmysql.dll"


### PR DESCRIPTION
On my systems the libmysqlclient version has moved to 16 and 18. Haven't tested extensively but connecting to database and closing again works.

Not sure if this is the proper way of doing this.