### PR TITLE
Implement re.replace(string, Regex, proc(...)) , simplify implmentation

### DIFF
--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -309,6 +309,9 @@ proc replace*(s: string, sub: Regex,
   ## `by` should never return `nil`
   result = ""
   var prev = 0
+  var capCount: int
+  # this should never fail
+  discard fullinfo(sub.h, sub.e, INFO_CAPTURECOUNT, addr capCount)
   while true:
     var matches: array[MaxSubpatterns, string]
     var match = s.findBounds(sub, matches, prev)
@@ -316,7 +319,7 @@ proc replace*(s: string, sub: Regex,
     if match.first < 0: break
 
     result.add(s.substr(prev, match.first - 1))
-    let nextReplacement = by(matches)
+    let nextReplacement = by(matches[0..(capCount - 1)])
     assert(nextReplacement != nil)
     result.add(nextReplacement)
 

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -323,15 +323,7 @@ proc replace*(s: string, sub: Regex, by = ""): string =
   ## .. code-block:: nim
   ##
   ##   "; "
-  result = ""
-  var prev = 0
-  while true:
-    var match = findBounds(s, sub, prev)
-    if match.first < 0: break
-    add(result, substr(s, prev, match.first-1))
-    add(result, by)
-    prev = match.last + 1
-  add(result, substr(s, prev))
+  return s.replace(sub, proc (m: openarray[string]): string = return by)
 
 proc replacef*(s: string, sub: Regex, by: string): string =
   ## Replaces `sub` in `s` by the string `by`. Captures can be accessed in `by`
@@ -345,18 +337,7 @@ proc replacef*(s: string, sub: Regex, by: string): string =
   ## .. code-block:: nim
   ##
   ## "var1<-keykey; val2<-key2key2"
-  result = ""
-  var caps: array[0..MaxSubpatterns-1, string]
-  var prev = 0
-  while true:
-    var match = findBounds(s, sub, caps, prev)
-    if match.first < 0: break
-    assert result != nil
-    assert s != nil
-    add(result, substr(s, prev, match.first-1))
-    addf(result, by, caps)
-    prev = match.last + 1
-  add(result, substr(s, prev))
+  return s.replace(sub, proc (caps: openarray[string]): string = return by % caps)
 
 proc parallelReplace*(s: string, subs: openArray[
                       tuple[pattern: Regex, repl: string]]): string =

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -299,7 +299,7 @@ proc replace*(s: string, sub: Regex, by: proc(s: string): string): string =
     prev = match.last + 1
   add(result, substr(s, prev))
 
-proc replace*(s: string, sub: Regex,
+proc replacef*(s: string, sub: Regex,
               by: proc(matches: openarray[string]): string): string =
   ## Replaces each occurance of `sub` in `s` by the result of the
   ## `by` expression. The captures are provided, and accessing

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -286,6 +286,35 @@ proc endsWith*(s: string, suffix: Regex): bool =
   for i in 0 .. s.len-1:
     if matchLen(s, suffix, i) == s.len - i: return true
 
+proc replace*(s: string, sub: Regex, by: proc(s: string): string): string =
+  ## Replaces `sub` in `s` by the results of calling the proc `by` with
+  ## each matched string.
+  result = ""
+  var prev = 0
+  while true:
+    var match = findBounds(s, sub, prev)
+    if match.first < 0: break
+    add(result, substr(s, prev, match.first-1))
+    add(result, by(substr(s, match.first, match.last)))
+    prev = match.last + 1
+  add(result, substr(s, prev))
+
+proc replacef*(s: string, sub: Regex, 
+               by: proc(m: openArray[string]): string): string =
+  ## Replaces `sub` in `s` by the results of calling the proc `by` with
+  ## each array of captures.
+  result = ""
+  var caps: array[0..MaxSubpatterns-1, string]
+  var prev = 0
+  while true:
+    var match = findBounds(s, sub, caps, prev)
+    if match.first < 0: break
+    add(result, substr(s, prev, match.first-1))
+    let capCount = find(caps, string(nil))
+    add(result, by(caps[0..capCount-1]))
+    prev = match.last + 1
+  add(result, substr(s, prev))
+
 proc replace*(s: string, sub: Regex,
               by: proc(matches: openarray[string]): string): string =
   ## Replaces each occurance of `sub` in `s` by the result of the

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -299,22 +299,6 @@ proc replace*(s: string, sub: Regex, by: proc(s: string): string): string =
     prev = match.last + 1
   add(result, substr(s, prev))
 
-proc replacef*(s: string, sub: Regex, 
-               by: proc(m: openArray[string]): string): string =
-  ## Replaces `sub` in `s` by the results of calling the proc `by` with
-  ## each array of captures.
-  result = ""
-  var caps: array[0..MaxSubpatterns-1, string]
-  var prev = 0
-  while true:
-    var match = findBounds(s, sub, caps, prev)
-    if match.first < 0: break
-    add(result, substr(s, prev, match.first-1))
-    let capCount = find(caps, string(nil))
-    add(result, by(caps[0..capCount-1]))
-    prev = match.last + 1
-  add(result, substr(s, prev))
-
 proc replace*(s: string, sub: Regex,
               by: proc(matches: openarray[string]): string): string =
   ## Replaces each occurance of `sub` in `s` by the result of the


### PR DESCRIPTION
Exactly what it says on the tin.

I'd like to sneak 1bfc93c in, but the real meat is in 0aba0f5.