### PR TITLE
Json stuff

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -665,9 +665,7 @@ proc toJson(x: expr): expr {.compiletime.} =
 macro `%*`*(x: expr): expr =
   ## Convert an expression to a JsonParser directly, without having to specify
   ## `%` for every element.
-  echo x.treeRepr
   result = toJson(x)
-  echo result.treeRepr
 
 proc `==`* (a,b: JsonNode): bool =
   ## Check two nodes for equality

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -864,7 +864,7 @@ proc pretty*(node: JsonNode, indent = 2): string =
 proc `$`*(node: JsonNode): string =
   ## Converts `node` to its JSON Representation on one line.
   result = ""
-  toPretty(result, node, 1, false)
+  toPretty(result, node, 0, false)
 
 iterator items*(node: JsonNode): JsonNode =
   ## Iterator for the items of `node`. `node` has to be a JArray.

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -644,7 +644,7 @@ proc `%`*(elements: openArray[JsonNode]): JsonNode =
   newSeq(result.elems, elements.len)
   for i, p in pairs(elements): result.elems[i] = p
 
-proc toJson(x: expr): expr {.compiletime.} =
+proc toJson(x: PNimrodNode): PNimrodNode {.compiletime.} =
   case x.kind
   of nnkBracket:
     result = newNimNode(nnkBracket)
@@ -663,7 +663,7 @@ proc toJson(x: expr): expr {.compiletime.} =
   result = prefix(result, "%")
 
 macro `%*`*(x: expr): expr =
-  ## Convert an expression to a JsonParser directly, without having to specify
+  ## Convert an expression to a JsonNode directly, without having to specify
   ## `%` for every element.
   result = toJson(x)
 


### PR DESCRIPTION
Some people said it's a pain to generate JSON in Nim. Since Nim is statically typed you can't just write
```nim
var j = [{"name": "John", "age": 30}, {"name": "Susan", "age": 31}]
```
Instead you have to add a `%` everywhere to convert to JSON:
```nim
var j = %[%{"name": %"John", "age": %30}, %{"name": %"Susan", "age": %31}]
```
That's annoying if you just want to paste some actual JSON into your source and set a few variables. The new `%*` macro automatically adds `%` where necessary. So you can now write:
```nim
var j = %*[{"name": "John", "age": 30}, {"name": "Susan", "age": 31}]
```
Or even with pretty indentation of your choice:
```nim
var j2 = %*
  [
    {
      "name": "John",
      "age": 30
    },
    {
      "name": "Susan",
      "age": 31
    }
  ]
echo j2

var name = "John"
let herAge = 30
const hisAge = 31

var j3 = %*
  [ { "name": name
    , "age": herAge
    }
  , { "name": "Susan"
    , "age": hisAge
    }
  ]
echo j3
```