### PR TITLE
Change recommended boot flags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ sh build.sh
 cd ".."
 
 ./bin/nim c koch
-./koch boot -d:release
+./koch boot -d:release --stacktrace:on -d:useGnuReadline
 
 cp -f install.sh.template install.sh
 chmod +x install.sh

--- a/doc/intern.txt
+++ b/doc/intern.txt
@@ -50,7 +50,7 @@ Compiling the compiler is a simple matter of running::
 For a release version use::
 
   nim c koch.nim
-  ./koch boot -d:release
+  ./koch boot -d:release --stackTrace:on
 
 And for a debug version compatible with GDB::
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ git clone --depth 1 git://github.com/nim-lang/csources
 $ cd csources && sh build.sh
 $ cd ..
 $ bin/nim c koch
-$ ./koch boot -d:release
+$ ./koch boot -d:release --stackTrace:on
 ```
 
 ``koch install [dir]`` may then be used to install Nim, or you can simply

--- a/web/download.txt
+++ b/web/download.txt
@@ -43,7 +43,7 @@ Change the branch to suit your needs::
   cd csources && sh build.sh
   cd ..
   bin/nim c koch
-  ./koch boot -d:release
+  ./koch boot -d:release --stackTrace:on
 
 The ``master`` branch always contains the latest stable version of the compiler.
 If you want bleeding edge then switch to the ``devel`` branch and follow


### PR DESCRIPTION
On *nix, where people might use the build.sh file, I've added readline as they can be reasonably expected to have it installed.

I've also added `--stacktrace:on` in order to make reporting and working around compiler bugs easier.