### PR TITLE
Add csources to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ xcuserdata/
 /testresults.html
 /testresults.json
 testament.db
+/csources/


### PR DESCRIPTION
I accidentally staged `csources`, and it took a long time to unstage it. Hopefully this will save someone that hassle.