### PR TITLE
Properly use the terminal module

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -209,3 +209,5 @@ if envOutLvl.len > 0:
     if $opt == envOutLvl:
       outputLevel = opt
       break
+
+system.addQuitProc(resetAttributes)


### PR DESCRIPTION
The documentation for terminal says

> Changing the style is permanent even after program termination! Use the code
> `system.addQuitProc(resetAttributes)` to restore the defaults.