### PR TITLE
Fix #1832

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1024,11 +1024,16 @@ proc genStrAppend(p: BProc, e: PNode, d: var TLoc) =
 proc genSeqElemAppend(p: BProc, e: PNode, d: var TLoc) =
   # seq &= x  -->
   #    seq = (typeof seq) incrSeq(&seq->Sup, sizeof(x));
-  #    seq->data[seq->len-1] = x;
+  #    seq->data[seq->len] = x;
+  #    seq->len += 1;
   let seqAppendPattern = if not p.module.compileToCpp:
                            "$1 = ($2) #incrSeq(&($1)->Sup, sizeof($3));$n"
                          else:
                            "$1 = ($2) #incrSeq($1, sizeof($3));$n"
+  let seqIncLenPattern = if optOverflowCheck notin p.options:
+                           "$1->$2 += 1;$n"
+                         else:
+                           "$1->$2 = #addInt($1->$2, 1);$n"
   var a, b, dest: TLoc
   initLocExpr(p, e.sons[1], a)
   initLocExpr(p, e.sons[2], b)
@@ -1038,8 +1043,9 @@ proc genSeqElemAppend(p: BProc, e: PNode, d: var TLoc) =
       getTypeDesc(p.module, skipTypes(e.sons[2].typ, abstractVar))])
   keepAlive(p, a)
   initLoc(dest, locExpr, b.t, OnHeap)
-  dest.r = rfmt(nil, "$1->data[$1->$2-1]", rdLoc(a), lenField(p))
+  dest.r = rfmt(nil, "$1->data[$1->$2]", rdLoc(a), lenField(p))
   genAssignment(p, dest, b, {needToCopy, afDestIsNil})
+  lineCg(p, cpsStmts, seqIncLenPattern, rdLoc(a), lenField(p))
   gcUsage(e)
 
 proc genReset(p: BProc, n: PNode) = 

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -161,6 +161,7 @@ proc extendSeq*(x: TAny) =
   var z = incrSeq(y, x.rawType.base.size)
   # 'incrSeq' already freed the memory for us and copied over the RC!
   # So we simply copy the raw pointer into 'x.value':
+  inc(z.len)
   cast[ppointer](x.value)[] = z
   #genericShallowAssign(x.value, addr(z), x.rawType)
 

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -186,13 +186,13 @@ proc incrSeq(seq: PGenericSeq, elemSize: int): PGenericSeq {.compilerProc.} =
   #
   #  add(seq, x)  generates:
   #  seq = incrSeq(seq, sizeof(x));
-  #  seq[seq->len-1] = x;
+  #  seq[seq->len] = x;
+  #  seq->len += 1;
   result = seq
   if result.len >= result.space:
     result.reserved = resize(result.space)
     result = cast[PGenericSeq](growObj(result, elemSize * result.reserved +
                                GenericSeqSize))
-  inc(result.len)
 
 proc setLengthSeq(seq: PGenericSeq, elemSize, newLen: int): PGenericSeq {.
     compilerRtl.} =


### PR DESCRIPTION
This PR fixes #1832 by creating a temporary variable on the stack and copy the value over before extending the seq and then copy the data over to the seq after extension.

Added documentation for `getTemp`, `needToCopy` and `afDestIsNil`.