### PR TITLE
doc/tut2.txt: clarified usage of static/dynamic binding

### DIFF
--- a/doc/tut2.txt
+++ b/doc/tut2.txt
@@ -304,8 +304,8 @@ Procedures always use static dispatch. For dynamic dispatch replace the
   echo eval(newPlus(newPlus(newLit(1), newLit(2)), newLit(4)))
 
 Note that in the example the constructors ``newLit`` and ``newPlus`` are procs
-because they should use static binding, but ``eval`` is a method because it
-requires dynamic binding.
+because it makes more sense for them to use static binding, but ``eval`` is a
+method because it requires dynamic binding.
 
 In a multi-method all parameters that have an object type are used for the
 dispatching:


### PR DESCRIPTION
The original text was slightly misleading in that it could be read that newLit and newPlus could not be implemented as methods; this is untrue, because newPlus could also be impleented as a method. The reason that newLit can't be implemented as a method is that its first argument (x: int) has a non-object type.