### PR TITLE
Improve documentation CSS for smaller resolutions

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -163,12 +163,12 @@ body {
 /* For devices larger than 400px */
 @media (min-width: 400px) {
   .container {
-    width: 85%;
+    width: 100%;
     padding: 0; } }
 /* For devices larger than 650px */
 @media (min-width: 650px) {
   .container {
-    width: 80%; }
+    width: 100%; }
 
   .column,
   .columns {
@@ -481,7 +481,7 @@ h6 {
 ul,
 ol {
   padding: 0;
-  margin: 0 0 10px 25px; }
+  margin: 0 0 0px 15px; }
 
 ul ul,
 ul ol,
@@ -574,15 +574,16 @@ code {
   border: 1px solid #777777; }
 
 pre {
-  display: block;
+  display: inline-block;
+  box-sizing: border-box;
+  min-width: calc(100% - 19.5px);
   padding: 9.5px;
-  margin: 0 10px 10px 10px;
+  margin: 0 10px 0px 10px;
   font-size: 14px;
   line-height: 20px;
   white-space: pre !important;
   overflow-y: hidden;
-  overflow: visible;
-  overflow-x: auto;
+  overflow-x: visible;
   background-color: whitesmoke;
   border: 1px solid #cccccc;
   -webkit-border-radius: 4px;
@@ -596,7 +597,7 @@ pre code {
   padding: 0;
   color: inherit;
   white-space: pre;
-  overflow-x: scroll;
+  overflow-x: visible;
   background-color: transparent;
   border: 0; }
 


### PR DESCRIPTION
Improves usability of the documentation with low resolutions. See the following examples of what changed:
Old:
![screenshot-20150111 044311](https://cloud.githubusercontent.com/assets/2335377/5694279/b42c8fd2-994c-11e4-8f94-a7a3f7114fb8.png)
New:
![screenshot-20150111 044314](https://cloud.githubusercontent.com/assets/2335377/5694276/b4266e04-994c-11e4-9e59-5475089f44cd.png)
Old:
![screenshot-20150111 044339](https://cloud.githubusercontent.com/assets/2335377/5694277/b4274dba-994c-11e4-96b3-a58cefd9a808.png)
New:
![screenshot-20150111 044341](https://cloud.githubusercontent.com/assets/2335377/5694278/b42bb79c-994c-11e4-846b-2c1f4d178408.png)

