### PR TITLE
Only handle EPOLLERR as an error event, as with EPOLLRDHUP there can sti...

### DIFF
--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -157,8 +157,6 @@ elif defined(linux):
     
       var evSet: set[Event] = {}
       if (s.events[i].events and EPOLLERR) != 0: evSet = evSet + {EvError}
-      if (s.events[i].events and EPOLLHUP) != 0: evSet = evSet + {EvError}
-      if (s.events[i].events and EPOLLRDHUP) != 0: evSet = evSet + {EvError}
       if (s.events[i].events and EPOLLIN) != 0: evSet = evSet + {EvRead}
       if (s.events[i].events and EPOLLOUT) != 0: evSet = evSet + {EvWrite}
       let selectorKey = s.fds[fd]


### PR DESCRIPTION
...ll be data to be read.

Fixes tasyncwait. I'm still not sure if we need to handle EPOLLRDHUP and EPOLLHUP in any way.