### PR TITLE
fixes issue with CreateSymLink and CreateHardLink on Windows XP and less via conditional symbol

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1407,7 +1407,7 @@ proc createSymlink*(src, dest: string) =
   ## Some OS's (such as Microsoft Windows) restrict the creation 
   ## of symlinks to root users (administrators).
   when defined(Windows):
-    when not isWinXPOrLess:
+    when not defined(winPreVista):
       let flag = dirExists(src).int32
       when useWinUnicode:
         var wSrc = newWideCString(src)
@@ -1428,7 +1428,7 @@ proc createHardlink*(src, dest: string) =
   ## **Warning**: Most OS's restrict the creation of hard links to 
   ## root users (administrators) .
   when defined(Windows):
-    when not isWinXPOrLess:
+    when not defined(winPreVista):
       when useWinUnicode:
         var wSrc = newWideCString(src)
         var wDst = newWideCString(dest)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1428,15 +1428,14 @@ proc createHardlink*(src, dest: string) =
   ## **Warning**: Most OS's restrict the creation of hard links to 
   ## root users (administrators) .
   when defined(Windows):
-    when not defined(winPreVista):
-      when useWinUnicode:
-        var wSrc = newWideCString(src)
-        var wDst = newWideCString(dest)
-        if createHardLinkW(wDst, wSrc, nil) == 0:
-          raiseOSError(osLastError())
-      else:
-        if createHardLinkA(dest, src, nil) == 0:
-          raiseOSError(osLastError())
+    when useWinUnicode:
+      var wSrc = newWideCString(src)
+      var wDst = newWideCString(dest)
+      if createHardLinkW(wDst, wSrc, nil) == 0:
+        raiseOSError(osLastError())
+    else:
+      if createHardLinkA(dest, src, nil) == 0:
+        raiseOSError(osLastError())
   else:
     if link(src, dest) != 0:
       raiseOSError(osLastError())

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1407,15 +1407,16 @@ proc createSymlink*(src, dest: string) =
   ## Some OS's (such as Microsoft Windows) restrict the creation 
   ## of symlinks to root users (administrators).
   when defined(Windows):
-    let flag = dirExists(src).int32
-    when useWinUnicode:
-      var wSrc = newWideCString(src)
-      var wDst = newWideCString(dest)
-      if createSymbolicLinkW(wDst, wSrc, flag) == 0 or getLastError() != 0:
-        raiseOSError(osLastError())
-    else:
-      if createSymbolicLinkA(dest, src, flag) == 0 or getLastError() != 0:
-        raiseOSError(osLastError())
+    when not isWinXPOrLess:
+      let flag = dirExists(src).int32
+      when useWinUnicode:
+        var wSrc = newWideCString(src)
+        var wDst = newWideCString(dest)
+        if createSymbolicLinkW(wDst, wSrc, flag) == 0 or getLastError() != 0:
+          raiseOSError(osLastError())
+      else:
+        if createSymbolicLinkA(dest, src, flag) == 0 or getLastError() != 0:
+          raiseOSError(osLastError())
   else:
     if symlink(src, dest) != 0:
       raiseOSError(osLastError())
@@ -1427,14 +1428,15 @@ proc createHardlink*(src, dest: string) =
   ## **Warning**: Most OS's restrict the creation of hard links to 
   ## root users (administrators) .
   when defined(Windows):
-    when useWinUnicode:
-      var wSrc = newWideCString(src)
-      var wDst = newWideCString(dest)
-      if createHardLinkW(wDst, wSrc, nil) == 0:
-        raiseOSError(osLastError())
-    else:
-      if createHardLinkA(dest, src, nil) == 0:
-        raiseOSError(osLastError())
+    when not isWinXPOrLess:
+      when useWinUnicode:
+        var wSrc = newWideCString(src)
+        var wDst = newWideCString(dest)
+        if createHardLinkW(wDst, wSrc, nil) == 0:
+          raiseOSError(osLastError())
+      else:
+        if createHardLinkA(dest, src, nil) == 0:
+          raiseOSError(osLastError())
   else:
     if link(src, dest) != 0:
       raiseOSError(osLastError())

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -209,17 +209,7 @@ else:
   proc getModuleFileNameA*(handle: THandle, buf: cstring, size: int32): int32 {.
     importc: "GetModuleFileNameA", dynlib: "kernel32", stdcall.}
 
-proc winXPOrLess: bool {.compiletime.} =
-  let ver = "cmd /c ver".gorge
-  # here we get something like "Microsoft Windows XP [Version 5.1.2600]"
-  var i = ver.len
-  while i > 0:
-    if ver[i] == ' ': break
-    dec i
-  i == 0 or (ver[i+1] > '1' and ver[i+1] < '6')
-const isWinXPOrLess* = winXPOrLess()
-
-when not isWinXPOrLess:
+when not defined(winPreVista):
   when useWinUnicode:
     proc createSymbolicLinkW*(lpSymlinkFileName, lpTargetFileName: WideCString,
                            flags: DWORD): int32 {.

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -209,21 +209,22 @@ else:
   proc getModuleFileNameA*(handle: THandle, buf: cstring, size: int32): int32 {.
     importc: "GetModuleFileNameA", dynlib: "kernel32", stdcall.}
 
-when not defined(winPreVista):
-  when useWinUnicode:
+when useWinUnicode:
+  when not defined(winPreVista):
     proc createSymbolicLinkW*(lpSymlinkFileName, lpTargetFileName: WideCString,
                            flags: DWORD): int32 {.
       importc:"CreateSymbolicLinkW", dynlib: "kernel32", stdcall.}
-    proc createHardLinkW*(lpFileName, lpExistingFileName: WideCString,
-                           security: pointer=nil): int32 {.
-      importc:"CreateHardLinkW", dynlib: "kernel32", stdcall.}
-  else:
+  proc createHardLinkW*(lpFileName, lpExistingFileName: WideCString,
+                         security: pointer=nil): int32 {.
+    importc:"CreateHardLinkW", dynlib: "kernel32", stdcall.}
+else:
+  when not defined(winPreVista):
     proc createSymbolicLinkA*(lpSymlinkFileName, lpTargetFileName: cstring,
                              flags: DWORD): int32 {.
       importc:"CreateSymbolicLinkA", dynlib: "kernel32", stdcall.}
-    proc createHardLinkA*(lpFileName, lpExistingFileName: cstring,
-                             security: pointer=nil): int32 {.
-      importc:"CreateHardLinkA", dynlib: "kernel32", stdcall.}
+  proc createHardLinkA*(lpFileName, lpExistingFileName: cstring,
+                           security: pointer=nil): int32 {.
+    importc:"CreateHardLinkA", dynlib: "kernel32", stdcall.}
 
 const
   FILE_ATTRIBUTE_ARCHIVE* = 32'i32


### PR DESCRIPTION
`--define: winPreVista` should be added by user to his *nim.cfg* or command line. There's an alternative PR getting Windows version via `cmd /c ver`.