### PR TITLE
GitHub link fixes: nim-code -> nim-lang

### DIFF
--- a/doc/backends.txt
+++ b/doc/backends.txt
@@ -338,7 +338,7 @@ in the ``nimcache`` directory. The naming of these files follows the pattern
 ``nimblePackageName_`` + ``nimSource``:
 
 * Filenames for modules imported from `nimble packages
-  <https://github.com/nim-code/nimble>`_ will end up with
+  <https://github.com/nim-lang/nimble>`_ will end up with
   ``nimblePackageName_module.c``. For example, if you import the
   ``argument_parser`` module from the same name nimble package you
   will end up with a ``argument_parser_argument_parser.c`` file

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -280,11 +280,11 @@ macro `<>`*(x: expr): expr {.immediate.} =
   ## Constructor macro for XML. Example usage:
   ##
   ## .. code-block:: nim
-  ##   <>a(href="http://nim-code.org", newText("Nim rules."))
+  ##   <>a(href="http://nim-lang.org", newText("Nim rules."))
   ##
   ## Produces an XML tree for::
   ##
-  ##  <a href="http://nim-code.org">Nim rules.</a>
+  ##  <a href="http://nim-lang.org">Nim rules.</a>
   ##
   let x = callsite()
   result = xmlConstructor(x)
@@ -343,5 +343,5 @@ proc findAll*(n: XmlNode, tag: string): seq[XmlNode] =
   findAll(n, tag, result)
 
 when isMainModule:
-  assert """<a href="http://nim-code.org">Nim rules.</a>""" ==
-    $(<>a(href="http://nim-code.org", newText("Nim rules.")))
+  assert """<a href="http://nim-lang.org">Nim rules.</a>""" ==
+    $(<>a(href="http://nim-lang.org", newText("Nim rules.")))

--- a/tests/manyloc/argument_parser/argument_parser.nim
+++ b/tests/manyloc/argument_parser/argument_parser.nim
@@ -1,7 +1,7 @@
 ## Command line parsing module for Nimrod.
 ##
-## `Nim <http://nim-code.org>`_ provides the `parseopt module
-## <http://nim-code.org/parseopt.html>`_ to parse options from the
+## `Nim <http://nim-lang.org>`_ provides the `parseopt module
+## <http://nim-lang.org/parseopt.html>`_ to parse options from the
 ## commandline. This module tries to provide functionality to prevent you from
 ## writing commandline parsing and let you concentrate on providing the best
 ## possible experience for your users.

--- a/web/nim.ini
+++ b/web/nim.ini
@@ -8,7 +8,7 @@ Authors: "Andreas Rumpf and contributors"
 # Underscores are replaced with a space.
 # Everything after ; is the ID
 Community: "community.html;link_forum"
-Aporia_IDE: "https://github.com/nim-code/Aporia;link_aporia"
+Aporia_IDE: "https://github.com/nim-lang/Aporia;link_aporia"
 Github_Repo: "http://github.com/Araq/Nim;link_github"
 
 

--- a/web/question.txt
+++ b/web/question.txt
@@ -104,11 +104,11 @@ General
   What about editor support?
   --------------------------
 
-  - Nim IDE: https://github.com/nim-code/Aporia
-  - Emacs: https://github.com/Tass/nimrod-mode
+  - Nim IDE: https://github.com/nim-lang/Aporia
+  - Emacs: https://github.com/Tass/nim-mode
   - Vim: https://github.com/zah/nimrod.vim/
   - Scite: Included
-  - Gedit: The `Aporia .lang file <https://github.com/nim-code/Aporia/blob/master/share/gtksourceview-2.0/language-specs/nimrod.lang>`_
+  - Gedit: The `Aporia .lang file <https://github.com/nim-lang/Aporia/blob/master/share/gtksourceview-2.0/language-specs/nimrod.lang>`_
   - jEdit: https://github.com/exhu/nimrod-misc/tree/master/jedit
   - TextMate: Available in bundle installer (`Repository <https://github.com/textmate/nim.tmbundle>`_)
 


### PR DESCRIPTION
Fix broken links, looked into it since reported here by MikeP: http://forum.nim-lang.org/t/753