### PR TITLE
Handle EPOLLHUP to avoid chaos/runaways when using certain fds

### DIFF
--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -156,7 +156,7 @@ elif defined(linux):
       let fd = s.events[i].data.fd.SocketHandle
     
       var evSet: set[Event] = {}
-      if (s.events[i].events and EPOLLERR) != 0: evSet = evSet + {EvError}
+      if (s.events[i].events and EPOLLERR) != 0 or (s.events[i].events and EPOLLHUP) != 0: evSet = evSet + {EvError}
       if (s.events[i].events and EPOLLIN) != 0: evSet = evSet + {EvRead}
       if (s.events[i].events and EPOLLOUT) != 0: evSet = evSet + {EvWrite}
       let selectorKey = s.fds[fd]


### PR DESCRIPTION
A concrete example is pipe file descriptors: they generate EPOLLHUP instead of a EPOLLIN (then 0 bytes read). The **loop will run wild if this event is not handled**.

This is rather hard to pinpoint because the loop will run wild, and you'll wonder where did you forget to read/write a socket/fd.