### PR TITLE
setControlCHook's parameter is not nil now

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2509,7 +2509,7 @@ when not defined(JS): #and not defined(NimrodVM):
     initGC()
 
   when not defined(NimrodVM):
-    proc setControlCHook*(hook: proc () {.noconv.})
+    proc setControlCHook*(hook: proc () {.noconv.} not nil)
       ## allows you to override the behaviour of your application when CTRL+C
       ## is pressed. Only one such hook is supported.
       


### PR DESCRIPTION
Currently the Nim compiler can't be built, should be fixed, was introduced in https://github.com/Araq/Nim/pull/2000