### PR TITLE
Algorithm to find the nodejs binary

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -15,7 +15,8 @@ when defined(gcc) and defined(windows):
 
 import
   commands, lexer, condsyms, options, msgs, nversion, nimconf, ropes,
-  extccomp, strutils, os, osproc, platform, main, parseopt, service
+  extccomp, strutils, os, osproc, platform, main, parseopt, service,
+  nodejs
 
 when hasTinyCBackend:
   import tccgen
@@ -67,7 +68,7 @@ proc handleCmdLine() =
           else:
             ex = quoteShell(
               completeCFilePath(changeFileExt(gProjectFull, "js").prependCurDir))
-          execExternalProgram("node " & ex & ' ' & commands.arguments)
+          execExternalProgram(findNodeJs & " " & ex & ' ' & commands.arguments)
         else:
           var binPath: string
           if options.outFile.len > 0:

--- a/lib/core/nodejs.nim
+++ b/lib/core/nodejs.nim
@@ -1,0 +1,6 @@
+import os
+
+proc findNodeJs*(): string =
+  result = findExe("nodejs")
+  if result == "":
+    result = findExe("node")

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -1,6 +1,6 @@
 discard """
   output: '''
-WARNING: false first asseertion from bar
+WARNING: false first assertion from bar
 ERROR: false second assertion from bar
 -1
 tfailedassert.nim:27 false assertion from foo
@@ -31,7 +31,7 @@ proc bar: int =
   # in this proc
   onFailedAssert(msg): echo "WARNING: " & msg
     
-  assert(false, "first asseertion from bar")
+  assert(false, "first assertion from bar")
 
   onFailedAssert(msg):
     echo "ERROR: " & msg

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -12,7 +12,7 @@
 import
   parseutils, strutils, pegs, os, osproc, streams, parsecfg, json,
   marshal, backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm
+  algorithm, nodejs
 
 const
   resultsFile = "testresults.html"
@@ -187,12 +187,13 @@ proc testSpec(r: var TResults, test: TTest) =
         else:
           exeFile = changeFileExt(tname, ExeExt)
         if existsFile(exeFile):
-          if test.target == targetJS and findExe("nodejs") == "":
+          let nodejs = findNodeJs()
+          if test.target == targetJS and nodejs == "":
             r.addResult(test, expected.outp, "nodejs binary not in PATH",
                         reExeNotFound)
             return
           var (buf, exitCode) = execCmdEx(
-            (if test.target == targetJS: "nodejs " else: "") & exeFile)
+            (if test.target == targetJS: nodejs & " " else: "") & exeFile)
           if exitCode != expected.exitCode:
             r.addResult(test, "exitcode: " & $expected.exitCode,
                               "exitcode: " & $exitCode, reExitCodesDiffer)


### PR DESCRIPTION
Upstream calls it `node`, debian calls it `nodejs`.