### PR TITLE
Fix parallel build on FreeBSD

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -1405,14 +1405,6 @@ var
     ## Report status of stopped child process.
   WEXITSTATUS* {.importc, header: "<sys/wait.h>".}: cint
     ## Return exit status.
-  WIFCONTINUED* {.importc, header: "<sys/wait.h>".}: cint
-    ## True if child has been continued.
-  WIFEXITED* {.importc, header: "<sys/wait.h>".}: cint
-    ## True if child exited normally.
-  WIFSIGNALED* {.importc, header: "<sys/wait.h>".}: cint
-    ## True if child exited due to uncaught signal.
-  WIFSTOPPED* {.importc, header: "<sys/wait.h>".}: cint
-    ## True if child is currently stopped.
   WSTOPSIG* {.importc, header: "<sys/wait.h>".}: cint
     ## Return signal number that caused process to stop.
   WTERMSIG* {.importc, header: "<sys/wait.h>".}: cint
@@ -1559,6 +1551,14 @@ var
   MSG_OOB* {.importc, header: "<sys/socket.h>".}: cint
     ## Out-of-band data.
 
+proc WIFCONTINUED*(s:cint) : bool {.importc, header: "<sys/wait.h>".}
+  ## True if child has been continued.
+proc WIFEXITED*(s:cint) : bool {.importc, header: "<sys/wait.h>".}
+  ## True if child exited normally.
+proc WIFSIGNALED*(s:cint) : bool {.importc, header: "<sys/wait.h>".}
+  ## True if child exited due to uncaught signal.
+proc WIFSTOPPED*(s:cint) : bool {.importc, header: "<sys/wait.h>".}
+  ## True if child is currently stopped.
 
 when defined(linux):
   var

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -848,7 +848,7 @@ elif not defined(useNimRtl):
     if kill(p.id, SIGCONT) != 0'i32: raiseOsError(osLastError())
 
   proc running(p: Process): bool =
-    var status : cint
+    var status : cint = 1
     var ret = waitpid(p.id, status, WNOHANG)
     if WIFEXITED(status):
       p.exitCode = status

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -848,10 +848,14 @@ elif not defined(useNimRtl):
     if kill(p.id, SIGCONT) != 0'i32: raiseOsError(osLastError())
 
   proc running(p: Process): bool =
-    var status : cint = 1
-    var ret = waitpid(p.id, status, WNOHANG)
-    if WIFEXITED(status):
-      p.exitCode = status
+    var ret : int
+    when not defined(freebsd):
+      ret = waitpid(p.id, p.exitCode, WNOHANG)
+    else:
+      var status : cint = 1
+      ret = waitpid(p.id, status, WNOHANG)
+      if WIFEXITED(status):
+        p.exitCode = status
     if ret == 0: return true # Can't establish status. Assume running.
     result = ret == int(p.id)
 

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -848,7 +848,10 @@ elif not defined(useNimRtl):
     if kill(p.id, SIGCONT) != 0'i32: raiseOsError(osLastError())
 
   proc running(p: Process): bool =
-    var ret = waitpid(p.id, p.exitCode, WNOHANG)
+    var status : cint
+    var ret = waitpid(p.id, status, WNOHANG)
+    if WIFEXITED(status):
+      p.exitCode = status
     if ret == 0: return true # Can't establish status. Assume running.
     result = ret == int(p.id)
 


### PR DESCRIPTION
This fixes the parallel build problem on FreeBSD and should not affect Linux builds. 
The problem was that FreeBSD's `waitpid()` changes its second parameter `status` even if the waited-for proccess has not exited, while Linux's doesn't. The nim compiler expects this parameter to be unchanged except when the process has ended.
I added a check `WIFEXITED` that is imported from `<sys/wait.h>` and changed the corresponding C imports.
I was not able to test this thoroughly under Linux as I currently only have an ancient VM image, but firsts tests showed no problems.