### PR TITLE
Remove T prefixes for TLock, TCond, TThread, TThreadId

### DIFF
--- a/doc/manual/locking.txt
+++ b/doc/manual/locking.txt
@@ -23,7 +23,7 @@ Protecting global variables
 Object fields and global variables can be annotated via a ``guard`` pragma:
 
 .. code-block:: nim
-  var glock: TLock
+  var glock: Lock
   var gdata {.guard: glock.}: int
 
 The compiler then ensures that every access of ``gdata`` is within a ``locks``
@@ -48,7 +48,7 @@ semantics and should not be used directly! It should only be used in templates
 that also implement some form of locking at runtime:
 
 .. code-block:: nim
-  template lock(a: TLock; body: stmt) =
+  template lock(a: Lock; body: stmt) =
     pthread_mutex_lock(a)
     {.locks: [a].}:
       try:
@@ -91,7 +91,7 @@ expressivity of the language:
   type
     ProtectedCounter = object
       v {.guard: L.}: int
-      L: TLock
+      L: Lock
 
   proc incCounters(counters: var openArray[ProtectedCounter]) =
     for i in 0..counters.high:
@@ -141,18 +141,18 @@ of the same level can only be acquired *at the same time* within a
 single ``locks`` section:
 
 .. code-block:: nim
-  var a, b: TLock[2]
-  var x: TLock[1]
-  # invalid locking order: TLock[1] cannot be acquired before TLock[2]:
+  var a, b: Lock[2]
+  var x: Lock[1]
+  # invalid locking order: Lock[1] cannot be acquired before Lock[2]:
   {.locks: [x].}: 
     {.locks: [a].}:
       ...
-  # valid locking order: TLock[2] acquired before TLock[1]:
+  # valid locking order: Lock[2] acquired before Lock[1]:
   {.locks: [a].}: 
     {.locks: [x].}:
       ...
 
-  # invalid locking order: TLock[2] acquired before TLock[2]:
+  # invalid locking order: Lock[2] acquired before Lock[2]:
   {.locks: [a].}: 
     {.locks: [b].}:
       ...
@@ -167,7 +167,7 @@ the runtime check is required to ensure a global ordering for two locks ``a``
 and ``b`` of the same lock level:
 
 .. code-block:: nim
-  template multilock(a, b: ptr TLock; body: stmt) =
+  template multilock(a, b: ptr Lock; body: stmt) =
     if cast[ByteAddress](a) < cast[ByteAddress](b):
       pthread_mutex_lock(a)
       pthread_mutex_lock(b)
@@ -189,7 +189,7 @@ This is essential so that procs can be called within a ``locks`` section:
 .. code-block:: nim
   proc p() {.locks: 3.} = discard 
 
-  var a: TLock[4]
+  var a: Lock[4]
   {.locks: [a].}:
     # p's locklevel (3) is strictly less than a's (4) so the call is allowed:
     p()

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -12,9 +12,9 @@
 include "system/syslocks"
 
 type
-  TLock* = TSysLock ## Nim lock; whether this is re-entrant
-                    ## or not is unspecified!
-  TCond* = TSysCond ## Nim condition variable
+  Lock* = TSysLock ## Nim lock; whether this is re-entrant
+                   ## or not is unspecified!
+  Cond* = TSysCond ## Nim condition variable
   
   LockEffect* {.deprecated.} = object of RootEffect ## \
     ## effect that denotes that some lock operation
@@ -26,42 +26,42 @@ type
     ## effect that denotes that some lock is
     ## released. Deprecated, do not use anymore!
 {.deprecated: [FLock: LockEffect, FAquireLock: AquireEffect, 
-    FReleaseLock: ReleaseEffect].}
+    FReleaseLock: ReleaseEffect, TLock: Lock, TCond: Cond].}
 
-proc initLock*(lock: var TLock) {.inline.} =
+proc initLock*(lock: var Lock) {.inline.} =
   ## Initializes the given lock.
   initSysLock(lock)
 
-proc deinitLock*(lock: var TLock) {.inline.} =
+proc deinitLock*(lock: var Lock) {.inline.} =
   ## Frees the resources associated with the lock.
   deinitSys(lock)
 
-proc tryAcquire*(lock: var TLock): bool = 
+proc tryAcquire*(lock: var Lock): bool = 
   ## Tries to acquire the given lock. Returns `true` on success.
   result = tryAcquireSys(lock)
 
-proc acquire*(lock: var TLock) =
+proc acquire*(lock: var Lock) =
   ## Acquires the given lock.
   acquireSys(lock)
   
-proc release*(lock: var TLock) =
+proc release*(lock: var Lock) =
   ## Releases the given lock.
   releaseSys(lock)
 
 
-proc initCond*(cond: var TCond) {.inline.} =
+proc initCond*(cond: var Cond) {.inline.} =
   ## Initializes the given condition variable.
   initSysCond(cond)
 
-proc deinitCond*(cond: var TCond) {.inline.} =
+proc deinitCond*(cond: var Cond) {.inline.} =
   ## Frees the resources associated with the lock.
   deinitSysCond(cond)
 
-proc wait*(cond: var TCond, lock: var TLock) {.inline.} =
+proc wait*(cond: var Cond, lock: var Lock) {.inline.} =
   ## waits on the condition variable `cond`. 
   waitSysCond(cond, lock)
   
-proc signal*(cond: var TCond) {.inline.} =
+proc signal*(cond: var Cond) {.inline.} =
   ## sends a signal to the condition variable `cond`. 
   signalSysCond(cond)
 

--- a/lib/pure/actors.nim
+++ b/lib/pure/actors.nim
@@ -40,7 +40,7 @@ type
 
   TActor[TIn, TOut] = object{.pure, final.}
     i: TChannel[TTask[TIn, TOut]]
-    t: TThread[ptr TActor[TIn, TOut]]
+    t: Thread[ptr TActor[TIn, TOut]]
     
   PActor*[TIn, TOut] = ptr TActor[TIn, TOut] ## an actor
   

--- a/lib/pure/collections/LockFreeHash.nim
+++ b/lib/pure/collections/LockFreeHash.nim
@@ -545,7 +545,7 @@ when isMainModule:
     Dict = PConcTable[string,TTestObj]
     
   var 
-    thr: array[0..numThreads-1, TThread[Dict]]
+    thr: array[0..numThreads-1, Thread[Dict]]
     
     table = newLFTable[string,TTestObj](8)        
     rand = newMersenneTwister(2525)

--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -18,8 +18,8 @@ import cpuinfo, cpuload, locks
 
 type
   Semaphore = object
-    c: TCond
-    L: TLock
+    c: Cond
+    L: Lock
     counter: int
 
 proc createSemaphore(): Semaphore =
@@ -113,7 +113,7 @@ type
 
   ToFreeQueue = object
     len: int
-    lock: TLock
+    lock: Lock
     empty: Semaphore
     data: array[128, pointer]
 
@@ -292,7 +292,7 @@ proc slave(w: ptr Worker) {.thread.} =
       atomicDec currentPoolSize
 
 var
-  workers: array[MaxThreadPoolSize, TThread[ptr Worker]]
+  workers: array[MaxThreadPoolSize, Thread[ptr Worker]]
   workersData: array[MaxThreadPoolSize, Worker]
 
 proc setMinPoolSize*(size: range[1..MaxThreadPoolSize]) =
@@ -349,7 +349,7 @@ proc parallel*(body: stmt) {.magic: "Parallel".}
 
 var
   state: ThreadPoolState
-  stateLock: TLock
+  stateLock: Lock
 
 initLock stateLock
 

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -62,7 +62,7 @@ when not defined(memProfiler):
 when withThreads:
   import locks
   var
-    profilingLock: TLock
+    profilingLock: Lock
 
   initLock profilingLock
 

--- a/lib/system/sysspawn.nim
+++ b/lib/system/sysspawn.nim
@@ -138,7 +138,7 @@ proc slave(w: ptr Worker) {.thread.} =
 const NumThreads = 4
 
 var
-  workers: array[NumThreads, TThread[ptr Worker]]
+  workers: array[NumThreads, Thread[ptr Worker]]
   workersData: array[NumThreads, Worker]
 
 proc setup() =

--- a/tests/generics/tthread_generic.nim
+++ b/tests/generics/tthread_generic.nim
@@ -14,8 +14,8 @@ proc handleThreadFunc(arg: TThreadFuncArgs[int]){.thread.} =
   callback(output)
 
 proc `@||->`*[T](fn: proc(): T {.thread.}, 
-                 callback: proc(val: T){.thread.}): TThread[TThreadFuncArgs[T]] =
-  var thr: TThread[TThreadFuncArgs[T]]
+                 callback: proc(val: T){.thread.}): Thread[TThreadFuncArgs[T]] =
+  var thr: Thread[TThreadFuncArgs[T]]
   var args: TThreadFuncArgs[T]
   args.a = fn
   args.b = callback

--- a/tests/parallel/tguard1.nim
+++ b/tests/parallel/tguard1.nim
@@ -1,6 +1,6 @@
 
 when false:
-  template lock(a, b: ptr TLock; body: stmt) =
+  template lock(a, b: ptr Lock; body: stmt) =
     if cast[ByteAddress](a) < cast[ByteAddress](b):
       pthread_mutex_lock(a)
       pthread_mutex_lock(b)

--- a/tests/threads/threadex.nim
+++ b/tests/threads/threadex.nim
@@ -11,7 +11,7 @@ type
     of mLine: data: string
 
 var
-  producer, consumer: TThread[void]
+  producer, consumer: Thread[void]
   chan: TChannel[TMsg]
   printedLines = 0
 

--- a/tests/threads/tthreadanalysis.nim
+++ b/tests/threads/tthreadanalysis.nim
@@ -8,7 +8,7 @@ discard """
 import os
 
 var
-  thr: array [0..5, TThread[tuple[a, b: int]]]
+  thr: array [0..5, Thread[tuple[a, b: int]]]
 
 proc doNothing() = discard
 

--- a/tests/threads/tthreadanalysis2.nim
+++ b/tests/threads/tthreadanalysis2.nim
@@ -8,7 +8,7 @@ discard """
 import os
 
 var
-  thr: array [0..5, TThread[tuple[a, b: int]]]
+  thr: array [0..5, Thread[tuple[a, b: int]]]
 
 proc doNothing() = discard
 

--- a/tests/threads/tthreadheapviolation1.nim
+++ b/tests/threads/tthreadheapviolation1.nim
@@ -6,7 +6,7 @@ discard """
 
 var 
   global: string = "test string"
-  t: TThread[void]
+  t: Thread[void]
 
 proc horrible() {.thread.} =
   global = "string in thread local heap!"

--- a/tests/threads/ttryrecv.nim
+++ b/tests/threads/ttryrecv.nim
@@ -15,7 +15,7 @@ proc doAction(outC: PComm) {.thread.} =
     send(outC[], i)
 
 var
-  thr: TThread[PComm]
+  thr: Thread[PComm]
   chan: TChannel[int]
 
 open(chan)

--- a/tests/types/tillegaltyperecursion.nim
+++ b/tests/types/tillegaltyperecursion.nim
@@ -17,7 +17,7 @@ type
         EventEmitter: TEventEmitter
         MessageReceivedHandler*: TEventHandler
         Socket: TSocket
-        Thread: TThread[TIRC]
+        Thread: Thread[TIRC]
         
 proc initIRC*(): TIRC =
     result.Socket = socket()
@@ -52,7 +52,7 @@ proc Connect*(irc: var TIRC, nick: string, host: string, port: int = 6667) =
     connect(irc.Socket ,host ,TPort(port),TDomain.AF_INET)
     send(irc.Socket,"USER " & nick & " " & nick & " " & nick & " " & nick &"\r\L")
     send(irc.Socket,"NICK " & nick & "\r\L")
-    var thread: TThread[TIRC]
+    var thread: Thread[TIRC]
     createThread(thread, handleData, irc)
     irc.Thread = thread
 


### PR DESCRIPTION
Again just the ones I noticed while coding something simple. I'm wondering whether we should semi-automatically rename all remaining T/P prefixes.