### PR TITLE
Koch temp 125 exit code

### DIFF
--- a/doc/intern.txt
+++ b/doc/intern.txt
@@ -145,6 +145,16 @@ are also lots of procs that aid in debugging:
     # why does it process temp.nim here?
     writeStackTrace()
 
+To create a new compiler for each run, use ``koch temp``::
+
+  ./koch temp c /tmp/test.nim
+
+``koch temp`` returns 125 as the exit code in case the compiler
+compilation fails. This exit code tells ``git bisect`` to skip the
+current commit.::
+
+  git bisect start bad-commit good-commit
+  git bisect ./koch -r c test-source.nim
 
 The compiler's architecture
 ===========================

--- a/doc/intern.txt
+++ b/doc/intern.txt
@@ -149,6 +149,9 @@ To create a new compiler for each run, use ``koch temp``::
 
   ./koch temp c /tmp/test.nim
 
+``koch temp`` creates a debug build of the compiler, which is useful
+to create stacktraces for compiler debugging.
+
 ``koch temp`` returns 125 as the exit code in case the compiler
 compilation fails. This exit code tells ``git bisect`` to skip the
 current commit.::

--- a/koch.nim
+++ b/koch.nim
@@ -77,9 +77,9 @@ proc findNim(): string =
   # assume there is a symlink to the exe or something:
   return nim
 
-proc exec(cmd: string) =
+proc exec(cmd: string, errorcode: int = QuitFailure) =
   echo(cmd)
-  if execShellCmd(cmd) != 0: quit("FAILURE")
+  if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
 
 proc tryExec(cmd: string): bool = 
   echo(cmd)
@@ -341,7 +341,9 @@ proc tests(args: string) =
 proc temp(args: string) =
   var output = "compiler" / "nim".exe
   var finalDest = "bin" / "nim_temp".exe
-  exec("nim c compiler" / "nim")
+  # 125 is the magic number to tell git bisect to skip the current
+  # commit.
+  exec("nim c compiler" / "nim", 125)
   copyExe(output, finalDest)
   if args.len > 0: exec(finalDest & " " & args)
 


### PR DESCRIPTION
I didn't test the git bisect part yet, due to lack of a proper example. Anything that calls the `exec` function now returns `1` upon failure.