### PR TITLE
Fix IRC channel at footer

### DIFF
--- a/tools/website.tmpl
+++ b/tools/website.tmpl
@@ -179,7 +179,7 @@ View at: localhost:5000
 					<div>
 						<h4>Community</h4>
 						<a href="http://forum.nim-lang.org">User Forum</a>
-            <a href="http://webchat.freenode.net/?channels=nimlang">Online IRC</a>
+            <a href="http://webchat.freenode.net/?channels=nim">Online IRC</a>
             <a href="http://irclogs.nim-lang.org/">IRC Logs</a>
 					</div>
 				</div>


### PR DESCRIPTION
01:47 < Danjcla> So the "Online IRC" link that's on the footer of the we site 
                 is links to "#nimlang" which is an invite-only channel. Is 
                 here a good place to report that, or should I open a bug or a 
                 forum thread?
01:47 < Danjcla> s/we/web/g