### PR TITLE
Same types for chars as in zlib.h

### DIFF
--- a/lib/wrappers/zip/zlib.nim
+++ b/lib/wrappers/zip/zlib.nim
@@ -119,9 +119,10 @@ proc gzputs*(thefile: GzFile, s: Pbytef): int32{.cdecl, dynlib: libz,
     importc: "gzputs".}
 proc gzgets*(thefile: GzFile, buf: Pbytef, length: int32): Pbytef{.cdecl, 
     dynlib: libz, importc: "gzgets".}
-proc gzputc*(thefile: GzFile, c: char): char{.cdecl, dynlib: libz, 
+proc gzputc*(thefile: GzFile, c: int): int{.cdecl, dynlib: libz, 
     importc: "gzputc".}
-proc gzgetc*(thefile: GzFile): char{.cdecl, dynlib: libz, importc: "gzgetc".}
+proc gzgetc*(thefile: GzFile): int{.cdecl, dynlib: libz, importc: "gzgetc".}
+proc gzungetc*(c: int, thefile: GzFile): int{.cdecl, dynlib: libz, importc: "gzungetc".}
 proc gzflush*(thefile: GzFile, flush: int32): int32{.cdecl, dynlib: libz, 
     importc: "gzflush".}
 proc gzseek*(thefile: GzFile, offset: ZOffT, whence: int32): ZOffT{.cdecl, 

--- a/lib/wrappers/zip/zlib.nim
+++ b/lib/wrappers/zip/zlib.nim
@@ -119,10 +119,10 @@ proc gzputs*(thefile: GzFile, s: Pbytef): int32{.cdecl, dynlib: libz,
     importc: "gzputs".}
 proc gzgets*(thefile: GzFile, buf: Pbytef, length: int32): Pbytef{.cdecl, 
     dynlib: libz, importc: "gzgets".}
-proc gzputc*(thefile: GzFile, c: int): int{.cdecl, dynlib: libz, 
+proc gzputc*(thefile: GzFile, c: int32): int32{.cdecl, dynlib: libz, 
     importc: "gzputc".}
-proc gzgetc*(thefile: GzFile): int{.cdecl, dynlib: libz, importc: "gzgetc".}
-proc gzungetc*(c: int, thefile: GzFile): int{.cdecl, dynlib: libz, importc: "gzungetc".}
+proc gzgetc*(thefile: GzFile): int32{.cdecl, dynlib: libz, importc: "gzgetc".}
+proc gzungetc*(c: int32, thefile: GzFile): int32{.cdecl, dynlib: libz, importc: "gzungetc".}
 proc gzflush*(thefile: GzFile, flush: int32): int32{.cdecl, dynlib: libz, 
     importc: "gzflush".}
 proc gzseek*(thefile: GzFile, offset: ZOffT, whence: int32): ZOffT{.cdecl, 


### PR DESCRIPTION
zlib sets the return value to -1 to communicate errors, which won't work if the parameter type is 'char'.

Also, one routine was missing.

Source: http://www.zlib.net/manual.html