### PR TITLE
Expose exception parent

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -343,7 +343,7 @@ type
     ##
     ## Each exception has to inherit from `Exception`. See the full `exception
     ## hierarchy`_.
-    parent: ref Exception     ## parent exception (can be used as a stack)
+    parent*: ref Exception     ## parent exception (can be used as a stack)
     name: cstring             ## The exception's name is its Nim identifier.
                               ## This field is filled automatically in the
                               ## ``raise`` statement.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -343,10 +343,10 @@ type
     ##
     ## Each exception has to inherit from `Exception`. See the full `exception
     ## hierarchy`_.
-    parent*: ref Exception     ## parent exception (can be used as a stack)
-    name: cstring             ## The exception's name is its Nim identifier.
-                              ## This field is filled automatically in the
-                              ## ``raise`` statement.
+    parent*: ref Exception ## parent exception (can be used as a stack)
+    name: cstring ## The exception's name is its Nim identifier.
+                  ## This field is filled automatically in the
+                  ## ``raise`` statement.
     msg* {.exportc: "message".}: string ## the exception's message. Not
                                         ## providing an exception message 
                                         ## is bad style.


### PR DESCRIPTION
This can be safely exposed because a proc accessor can be created if the representation changes.