### PR TITLE
newRollingFileLogger - fmtStr is always set to defaultFmtStr

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -186,7 +186,7 @@ proc newRollingFileLogger*(filename = defaultFilename(),
   ## a new log file will be started and the old will be renamed.
   new(result)
   result.levelThreshold = levelThreshold
-  result.fmtStr = defaultFmtStr
+  result.fmtStr = fmtStr
   result.maxLines = maxLines
   result.f = open(filename, mode)
   result.curLine = 0


### PR DESCRIPTION
Ported change from master to devel branch -- Sorry about that, I just followed a link in the docs.