### PR TITLE
Add support for compiling VxWorks PowerPC RTP applications

### DIFF
--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -138,7 +138,7 @@ const
       props: {ospNeedsPIC, ospPosix, ospLacksThreadVars}),
      (name: "VxWorks", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
       objExt: ".o", newLine: "\x0A", pathSep: ";", dirSep: "\\",
-      scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
+      scriptExt: ".sh", curDir: ".", exeExt: ".vxe", extSep: ".",
       props: {ospNeedsPIC, ospPosix, ospLacksThreadVars}),
      (name: "JS", parDir: "..", 
       dllFrmt: "lib$1.so", altDirSep: "/", 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -112,6 +112,20 @@ hint[LineTooLong]=off
   gcc.cpp.options.always = "-w -fpermissive"
 @end
 
+# Configuration for the VxWorks GCC compiler
+# This has only been tested with VxWorks 6.9
+@if vxworks:
+  # For now we only support compiling RTPs applications (i.e. no DKMs)
+  gcc.options.always = "-mrtp -fno-strict-aliasing -D_C99 -D_HAS_C9X -std=c99 -fasm -Wall -Wno-write-strings"
+  # The linker config must add the VxWorks common library for the selected
+  # processor which is usually found in:
+  # "$WIND_BASE/target/lib/usr/lib/PROCESSOR_FAMILY/PROCESSOR_TYPE/common",
+  # where PROCESSOR_FAMILY and PROCESSOR_TYPE are those supported by the VxWorks
+  # compiler (e.g. ppc/PPC32, mips/MIPSI32R2, mips/MIPSI64, arm/ARMARCH7, etc)
+  # For now we only support the PowerPC CPU
+  gcc.options.linker %= "-L $WIND_BASE/target/lib/usr/lib/ppc/PPC32/common -mrtp -fno-strict-aliasing -D_C99 -D_HAS_C9X -std=c99 -fasm -Wall -Wno-write-strings"
+@end
+
 gcc.options.speed = "-O3 -fno-strict-aliasing"
 gcc.options.size = "-Os"
 gcc.options.debug = "-g3 -O0"

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -390,3 +390,12 @@ typedef int assert_numbits[sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(
 #else
 #  define NIM_EXTERNC
 #endif
+
+/* ---------------- platform specific includes ----------------------- */
+
+/* VxWorks related includes */
+#if defined(__VXWORKS__)
+#  include <sys/types.h>
+#  include <types/vxWind.h>
+#  include <tool/gnu/toolMacros.h>
+#endif


### PR DESCRIPTION
For now we only support generating RTP applications for PowerPC CPUs.