### PR TITLE
Fixing dylib name for OSX

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -16,11 +16,11 @@ type
   TDbConn* = PMySQL    ## encapsulates a database connection
   TRow* = seq[string]  ## a row of a dataset. NULL database values will be
                        ## transformed always to the empty string.
-  EDb* = object of EIO ## exception that is raised if a database error occurs
+  EDb* = object of IOError ## exception that is raised if a database error occurs
 
   TSqlQuery* = distinct string ## an SQL query string
 
-  FDb* = object of FIO ## effect that denotes a database operation
+  FDb* = object of IOEffect ## effect that denotes a database operation
   FReadDb* = object of FDb   ## effect that denotes a read operation
   FWriteDb* = object of FDb  ## effect that denotes a write operation
 

--- a/lib/wrappers/mysql.nim
+++ b/lib/wrappers/mysql.nim
@@ -13,7 +13,7 @@
 when defined(Unix):
   when defined(macosx):
     const
-      lib = "libmysqlclient.(15|16|17[18).dylib"
+      lib = "libmysqlclient.(15|16|17|18).dylib"
   else:
     const
       lib = "libmysqlclient.so.(15|16|17|18)"


### PR DESCRIPTION
I don't know if the (15|16...) is supposed to work on OSX. I have "libmysqlclient.18.dylib" in my lib directory and get "could not load: libmysqlclient.(15|16|17[18).dylib" on execution. After removing the pattern I can run my little example program and it works as "libmysqlclient.dylib" is a softlink to the current version anyway. I also throw a deprecated names fix in.