### PR TITLE
fix conditions for int size in 'math.nextPowerOfTwo' #2110

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -93,9 +93,9 @@ proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
   result = x - 1 
   when defined(cpu64):
     result = result or (result shr 32)
-  when sizeof(int) > 16:
+  when sizeof(int) > 2:
     result = result or (result shr 16)
-  when sizeof(int) > 8:
+  when sizeof(int) > 1:
     result = result or (result shr 8)
   result = result or (result shr 4)
   result = result or (result shr 2)


### PR DESCRIPTION
This fixes #2110 . I could not find any guideline on how to contribute patches. Please let me know if I should add some testcase (how?) or do anything else.