### PR TITLE
Disable -pthread for compiler/linker on OSX

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -95,7 +95,9 @@ when defined(windows):
       importc: "TlsGetValue", stdcall, dynlib: "kernel32".}
   
 else:
-  {.passL: "-pthread".}
+  when not defined(macosx):
+    {.passL: "-pthread".}
+
   {.passC: "-pthread".}
 
   type


### PR DESCRIPTION
The -pthread is not needed on Darwin/OS X and the Apple compilers give a warning about this if you use --threads:on with the Nim compiler.