### PR TITLE
Changed terminal.getch to use getchar from stdio.h

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -45,7 +45,7 @@ when defined(windows):
   var
     oldAttr = getAttributes()
 
-  proc winGetch(): cint {.header: "<conio.h>", importc: "_getch".}
+  proc winGetch(): cint {.header: "<stdio.h>", importc: "getchar".}
 else:
   import termios, unsigned
 


### PR DESCRIPTION
This removes the `conio.h` dependency in the terminal module.

(please ignore the \n in the commit message, Git on Windows is frustrating :) )
