### PR TITLE
Commit OS X Framework declarations for Nim.

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -46,6 +46,7 @@ path="$lib/wrappers/zip"
 path="$lib/wrappers/libffi"
 path="$lib/windows"
 path="$lib/posix"
+path="$lib/osx/frameworks"
 path="$lib/js"
 path="$lib/pure/unidecode"
 
@@ -108,7 +109,7 @@ path="$lib/pure/unidecode"
   gcc.options.always = "-w -fasm-blocks"
   gcc.cpp.options.always = "-w -fasm-blocks -fpermissive"
 @else:
-  gcc.options.always = "-w" 
+  gcc.options.always = "-w"
   gcc.cpp.options.always = "-w -fpermissive"
 @end
 

--- a/lib/osx/frameworks/accelerate_framework.nim
+++ b/lib/osx/frameworks/accelerate_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Accelerate".}
+const ACCELERATE_FRAMEWORK_HEADER* = "<Accelerate/Accelerate.h>"
+

--- a/lib/osx/frameworks/accounts_framework.nim
+++ b/lib/osx/frameworks/accounts_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Accounts".}
+const ACCOUNTS_FRAMEWORK_HEADER* = "<Accounts/Accounts.h>"
+

--- a/lib/osx/frameworks/addressbook_framework.nim
+++ b/lib/osx/frameworks/addressbook_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AddressBook".}
+const ADDRESSBOOK_FRAMEWORK_HEADER* = "<AddressBook/AddressBook.h>"
+

--- a/lib/osx/frameworks/ae_framework.nim
+++ b/lib/osx/frameworks/ae_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AE".}
+const AE_FRAMEWORK_HEADER* = "<AE/AE.h>"
+

--- a/lib/osx/frameworks/agl_framework.nim
+++ b/lib/osx/frameworks/agl_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AGL".}
+const AGL_FRAMEWORK_HEADER* = "<AGL/AGL.h>"
+

--- a/lib/osx/frameworks/appkit_framework.nim
+++ b/lib/osx/frameworks/appkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AppKit".}
+const APPKIT_FRAMEWORK_HEADER* = "<AppKit/AppKit.h>"
+

--- a/lib/osx/frameworks/appkitscripting_framework.nim
+++ b/lib/osx/frameworks/appkitscripting_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AppKitScripting".}
+const APPKITSCRIPTING_FRAMEWORK_HEADER* = "<AppKitScripting/AppKitScripting.h>"
+

--- a/lib/osx/frameworks/applescriptkit_framework.nim
+++ b/lib/osx/frameworks/applescriptkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AppleScriptKit".}
+const APPLESCRIPTKIT_FRAMEWORK_HEADER* = "<AppleScriptKit/AppleScriptKit.h>"
+

--- a/lib/osx/frameworks/applescriptobjc_framework.nim
+++ b/lib/osx/frameworks/applescriptobjc_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AppleScriptObjC".}
+const APPLESCRIPTOBJC_FRAMEWORK_HEADER* = "<AppleScriptObjC/AppleScriptObjC.h>"
+

--- a/lib/osx/frameworks/applicationservices_framework.nim
+++ b/lib/osx/frameworks/applicationservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ApplicationServices".}
+const APPLICATIONSERVICES_FRAMEWORK_HEADER* = "<ApplicationServices/ApplicationServices.h>"
+

--- a/lib/osx/frameworks/ats_framework.nim
+++ b/lib/osx/frameworks/ats_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ATS".}
+const ATS_FRAMEWORK_HEADER* = "<ATS/ATS.h>"
+

--- a/lib/osx/frameworks/audiotoolbox_framework.nim
+++ b/lib/osx/frameworks/audiotoolbox_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AudioToolbox".}
+const AUDIOTOOLBOX_FRAMEWORK_HEADER* = "<AudioToolbox/AudioToolbox.h>"
+

--- a/lib/osx/frameworks/audiounit_framework.nim
+++ b/lib/osx/frameworks/audiounit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AudioUnit".}
+const AUDIOUNIT_FRAMEWORK_HEADER* = "<AudioUnit/AudioUnit.h>"
+

--- a/lib/osx/frameworks/audiovideobridging_framework.nim
+++ b/lib/osx/frameworks/audiovideobridging_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AudioVideoBridging".}
+const AUDIOVIDEOBRIDGING_FRAMEWORK_HEADER* = "<AudioVideoBridging/AudioVideoBridging.h>"
+

--- a/lib/osx/frameworks/automator_framework.nim
+++ b/lib/osx/frameworks/automator_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Automator".}
+const AUTOMATOR_FRAMEWORK_HEADER* = "<Automator/Automator.h>"
+

--- a/lib/osx/frameworks/avfoundation_framework.nim
+++ b/lib/osx/frameworks/avfoundation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AVFoundation".}
+const AVFOUNDATION_FRAMEWORK_HEADER* = "<AVFoundation/AVFoundation.h>"
+

--- a/lib/osx/frameworks/avkit_framework.nim
+++ b/lib/osx/frameworks/avkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework AVKit".}
+const AVKIT_FRAMEWORK_HEADER* = "<AVKit/AVKit.h>"
+

--- a/lib/osx/frameworks/calendarstore_framework.nim
+++ b/lib/osx/frameworks/calendarstore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CalendarStore".}
+const CALENDARSTORE_FRAMEWORK_HEADER* = "<CalendarStore/CalendarStore.h>"
+

--- a/lib/osx/frameworks/carbon_framework.nim
+++ b/lib/osx/frameworks/carbon_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Carbon".}
+const CARBON_FRAMEWORK_HEADER* = "<Carbon/Carbon.h>"
+

--- a/lib/osx/frameworks/carboncore_framework.nim
+++ b/lib/osx/frameworks/carboncore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CarbonCore".}
+const CARBONCORE_FRAMEWORK_HEADER* = "<CarbonCore/CarbonCore.h>"
+

--- a/lib/osx/frameworks/carbonsound_framework.nim
+++ b/lib/osx/frameworks/carbonsound_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CarbonSound".}
+const CARBONSOUND_FRAMEWORK_HEADER* = "<CarbonSound/CarbonSound.h>"
+

--- a/lib/osx/frameworks/cfnetwork_framework.nim
+++ b/lib/osx/frameworks/cfnetwork_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CFNetwork".}
+const CFNETWORK_FRAMEWORK_HEADER* = "<CFNetwork/CFNetwork.h>"
+

--- a/lib/osx/frameworks/cloudkit_framework.nim
+++ b/lib/osx/frameworks/cloudkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CloudKit".}
+const CLOUDKIT_FRAMEWORK_HEADER* = "<CloudKit/CloudKit.h>"
+

--- a/lib/osx/frameworks/cocoa_framework.nim
+++ b/lib/osx/frameworks/cocoa_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Cocoa".}
+const COCOA_FRAMEWORK_HEADER* = "<Cocoa/Cocoa.h>"
+

--- a/lib/osx/frameworks/collaboration_framework.nim
+++ b/lib/osx/frameworks/collaboration_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Collaboration".}
+const COLLABORATION_FRAMEWORK_HEADER* = "<Collaboration/Collaboration.h>"
+

--- a/lib/osx/frameworks/colorsync_framework.nim
+++ b/lib/osx/frameworks/colorsync_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ColorSync".}
+const COLORSYNC_FRAMEWORK_HEADER* = "<ColorSync/ColorSync.h>"
+

--- a/lib/osx/frameworks/commonpanels_framework.nim
+++ b/lib/osx/frameworks/commonpanels_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CommonPanels".}
+const COMMONPANELS_FRAMEWORK_HEADER* = "<CommonPanels/CommonPanels.h>"
+

--- a/lib/osx/frameworks/coreaudio_framework.nim
+++ b/lib/osx/frameworks/coreaudio_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreAudio".}
+const COREAUDIO_FRAMEWORK_HEADER* = "<CoreAudio/CoreAudio.h>"
+

--- a/lib/osx/frameworks/coreaudiokit_framework.nim
+++ b/lib/osx/frameworks/coreaudiokit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreAudioKit".}
+const COREAUDIOKIT_FRAMEWORK_HEADER* = "<CoreAudioKit/CoreAudioKit.h>"
+

--- a/lib/osx/frameworks/corebluetooth_framework.nim
+++ b/lib/osx/frameworks/corebluetooth_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreBluetooth".}
+const COREBLUETOOTH_FRAMEWORK_HEADER* = "<CoreBluetooth/CoreBluetooth.h>"
+

--- a/lib/osx/frameworks/coredata_framework.nim
+++ b/lib/osx/frameworks/coredata_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreData".}
+const COREDATA_FRAMEWORK_HEADER* = "<CoreData/CoreData.h>"
+

--- a/lib/osx/frameworks/corefoundation_framework.nim
+++ b/lib/osx/frameworks/corefoundation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreFoundation".}
+const COREFOUNDATION_FRAMEWORK_HEADER* = "<CoreFoundation/CoreFoundation.h>"
+

--- a/lib/osx/frameworks/coregraphics_framework.nim
+++ b/lib/osx/frameworks/coregraphics_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreGraphics".}
+const COREGRAPHICS_FRAMEWORK_HEADER* = "<CoreGraphics/CoreGraphics.h>"
+

--- a/lib/osx/frameworks/corelocation_framework.nim
+++ b/lib/osx/frameworks/corelocation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreLocation".}
+const CORELOCATION_FRAMEWORK_HEADER* = "<CoreLocation/CoreLocation.h>"
+

--- a/lib/osx/frameworks/coremedia_framework.nim
+++ b/lib/osx/frameworks/coremedia_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreMedia".}
+const COREMEDIA_FRAMEWORK_HEADER* = "<CoreMedia/CoreMedia.h>"
+

--- a/lib/osx/frameworks/coremediaio_framework.nim
+++ b/lib/osx/frameworks/coremediaio_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreMediaIO".}
+const COREMEDIAIO_FRAMEWORK_HEADER* = "<CoreMediaIO/CoreMediaIO.h>"
+

--- a/lib/osx/frameworks/coremidi_framework.nim
+++ b/lib/osx/frameworks/coremidi_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreMIDI".}
+const COREMIDI_FRAMEWORK_HEADER* = "<CoreMIDI/CoreMIDI.h>"
+

--- a/lib/osx/frameworks/coremidiserver_framework.nim
+++ b/lib/osx/frameworks/coremidiserver_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreMIDIServer".}
+const COREMIDISERVER_FRAMEWORK_HEADER* = "<CoreMIDIServer/CoreMIDIServer.h>"
+

--- a/lib/osx/frameworks/coreservices_framework.nim
+++ b/lib/osx/frameworks/coreservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreServices".}
+const CORESERVICES_FRAMEWORK_HEADER* = "<CoreServices/CoreServices.h>"
+

--- a/lib/osx/frameworks/coretext_framework.nim
+++ b/lib/osx/frameworks/coretext_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreText".}
+const CORETEXT_FRAMEWORK_HEADER* = "<CoreText/CoreText.h>"
+

--- a/lib/osx/frameworks/corevideo_framework.nim
+++ b/lib/osx/frameworks/corevideo_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreVideo".}
+const COREVIDEO_FRAMEWORK_HEADER* = "<CoreVideo/CoreVideo.h>"
+

--- a/lib/osx/frameworks/corewlan_framework.nim
+++ b/lib/osx/frameworks/corewlan_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CoreWLAN".}
+const COREWLAN_FRAMEWORK_HEADER* = "<CoreWLAN/CoreWLAN.h>"
+

--- a/lib/osx/frameworks/cryptotokenkit_framework.nim
+++ b/lib/osx/frameworks/cryptotokenkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework CryptoTokenKit".}
+const CRYPTOTOKENKIT_FRAMEWORK_HEADER* = "<CryptoTokenKit/CryptoTokenKit.h>"
+

--- a/lib/osx/frameworks/dictionaryservices_framework.nim
+++ b/lib/osx/frameworks/dictionaryservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DictionaryServices".}
+const DICTIONARYSERVICES_FRAMEWORK_HEADER* = "<DictionaryServices/DictionaryServices.h>"
+

--- a/lib/osx/frameworks/directoryservice_framework.nim
+++ b/lib/osx/frameworks/directoryservice_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DirectoryService".}
+const DIRECTORYSERVICE_FRAMEWORK_HEADER* = "<DirectoryService/DirectoryService.h>"
+

--- a/lib/osx/frameworks/discrecording_framework.nim
+++ b/lib/osx/frameworks/discrecording_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DiscRecording".}
+const DISCRECORDING_FRAMEWORK_HEADER* = "<DiscRecording/DiscRecording.h>"
+

--- a/lib/osx/frameworks/discrecordingui_framework.nim
+++ b/lib/osx/frameworks/discrecordingui_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DiscRecordingUI".}
+const DISCRECORDINGUI_FRAMEWORK_HEADER* = "<DiscRecordingUI/DiscRecordingUI.h>"
+

--- a/lib/osx/frameworks/diskarbitration_framework.nim
+++ b/lib/osx/frameworks/diskarbitration_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DiskArbitration".}
+const DISKARBITRATION_FRAMEWORK_HEADER* = "<DiskArbitration/DiskArbitration.h>"
+

--- a/lib/osx/frameworks/drawsprocket_framework.nim
+++ b/lib/osx/frameworks/drawsprocket_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DrawSprocket".}
+const DRAWSPROCKET_FRAMEWORK_HEADER* = "<DrawSprocket/DrawSprocket.h>"
+

--- a/lib/osx/frameworks/dvcomponentglue_framework.nim
+++ b/lib/osx/frameworks/dvcomponentglue_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DVComponentGlue".}
+const DVCOMPONENTGLUE_FRAMEWORK_HEADER* = "<DVComponentGlue/DVComponentGlue.h>"
+

--- a/lib/osx/frameworks/dvdplayback_framework.nim
+++ b/lib/osx/frameworks/dvdplayback_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework DVDPlayback".}
+const DVDPLAYBACK_FRAMEWORK_HEADER* = "<DVDPlayback/DVDPlayback.h>"
+

--- a/lib/osx/frameworks/eventkit_framework.nim
+++ b/lib/osx/frameworks/eventkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework EventKit".}
+const EVENTKIT_FRAMEWORK_HEADER* = "<EventKit/EventKit.h>"
+

--- a/lib/osx/frameworks/exceptionhandling_framework.nim
+++ b/lib/osx/frameworks/exceptionhandling_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ExceptionHandling".}
+const EXCEPTIONHANDLING_FRAMEWORK_HEADER* = "<ExceptionHandling/ExceptionHandling.h>"
+

--- a/lib/osx/frameworks/findersync_framework.nim
+++ b/lib/osx/frameworks/findersync_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework FinderSync".}
+const FINDERSYNC_FRAMEWORK_HEADER* = "<FinderSync/FinderSync.h>"
+

--- a/lib/osx/frameworks/forcefeedback_framework.nim
+++ b/lib/osx/frameworks/forcefeedback_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ForceFeedback".}
+const FORCEFEEDBACK_FRAMEWORK_HEADER* = "<ForceFeedback/ForceFeedback.h>"
+

--- a/lib/osx/frameworks/foundation_framework.nim
+++ b/lib/osx/frameworks/foundation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Foundation".}
+const FOUNDATION_FRAMEWORK_HEADER* = "<Foundation/Foundation.h>"
+

--- a/lib/osx/frameworks/fwauserlib_framework.nim
+++ b/lib/osx/frameworks/fwauserlib_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework FWAUserLib".}
+const FWAUSERLIB_FRAMEWORK_HEADER* = "<FWAUserLib/FWAUserLib.h>"
+

--- a/lib/osx/frameworks/gamecontroller_framework.nim
+++ b/lib/osx/frameworks/gamecontroller_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework GameController".}
+const GAMECONTROLLER_FRAMEWORK_HEADER* = "<GameController/GameController.h>"
+

--- a/lib/osx/frameworks/gamekit_framework.nim
+++ b/lib/osx/frameworks/gamekit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework GameKit".}
+const GAMEKIT_FRAMEWORK_HEADER* = "<GameKit/GameKit.h>"
+

--- a/lib/osx/frameworks/glkit_framework.nim
+++ b/lib/osx/frameworks/glkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework GLKit".}
+const GLKIT_FRAMEWORK_HEADER* = "<GLKit/GLKit.h>"
+

--- a/lib/osx/frameworks/glut_framework.nim
+++ b/lib/osx/frameworks/glut_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework GLUT".}
+const GLUT_FRAMEWORK_HEADER* = "<GLUT/GLUT.h>"
+

--- a/lib/osx/frameworks/gss_framework.nim
+++ b/lib/osx/frameworks/gss_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework GSS".}
+const GSS_FRAMEWORK_HEADER* = "<GSS/GSS.h>"
+

--- a/lib/osx/frameworks/help_framework.nim
+++ b/lib/osx/frameworks/help_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Help".}
+const HELP_FRAMEWORK_HEADER* = "<Help/Help.h>"
+

--- a/lib/osx/frameworks/hiservices_framework.nim
+++ b/lib/osx/frameworks/hiservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework HIServices".}
+const HISERVICES_FRAMEWORK_HEADER* = "<HIServices/HIServices.h>"
+

--- a/lib/osx/frameworks/hitoolbox_framework.nim
+++ b/lib/osx/frameworks/hitoolbox_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework HIToolbox".}
+const HITOOLBOX_FRAMEWORK_HEADER* = "<HIToolbox/HIToolbox.h>"
+

--- a/lib/osx/frameworks/htmlrendering_framework.nim
+++ b/lib/osx/frameworks/htmlrendering_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework HTMLRendering".}
+const HTMLRENDERING_FRAMEWORK_HEADER* = "<HTMLRendering/HTMLRendering.h>"
+

--- a/lib/osx/frameworks/icadevices_framework.nim
+++ b/lib/osx/frameworks/icadevices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ICADevices".}
+const ICADEVICES_FRAMEWORK_HEADER* = "<ICADevices/ICADevices.h>"
+

--- a/lib/osx/frameworks/imagecapture_framework.nim
+++ b/lib/osx/frameworks/imagecapture_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ImageCapture".}
+const IMAGECAPTURE_FRAMEWORK_HEADER* = "<ImageCapture/ImageCapture.h>"
+

--- a/lib/osx/frameworks/imagecapturecore_framework.nim
+++ b/lib/osx/frameworks/imagecapturecore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ImageCaptureCore".}
+const IMAGECAPTURECORE_FRAMEWORK_HEADER* = "<ImageCaptureCore/ImageCaptureCore.h>"
+

--- a/lib/osx/frameworks/imageio_framework.nim
+++ b/lib/osx/frameworks/imageio_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ImageIO".}
+const IMAGEIO_FRAMEWORK_HEADER* = "<ImageIO/ImageIO.h>"
+

--- a/lib/osx/frameworks/imagekit_framework.nim
+++ b/lib/osx/frameworks/imagekit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ImageKit".}
+const IMAGEKIT_FRAMEWORK_HEADER* = "<ImageKit/ImageKit.h>"
+

--- a/lib/osx/frameworks/imcore_framework.nim
+++ b/lib/osx/frameworks/imcore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IMCore".}
+const IMCORE_FRAMEWORK_HEADER* = "<IMCore/IMCore.h>"
+

--- a/lib/osx/frameworks/imserviceplugin_framework.nim
+++ b/lib/osx/frameworks/imserviceplugin_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IMServicePlugIn".}
+const IMSERVICEPLUGIN_FRAMEWORK_HEADER* = "<IMServicePlugIn/IMServicePlugIn.h>"
+

--- a/lib/osx/frameworks/imservicepluginsupport_framework.nim
+++ b/lib/osx/frameworks/imservicepluginsupport_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IMServicePlugInSupport".}
+const IMSERVICEPLUGINSUPPORT_FRAMEWORK_HEADER* = "<IMServicePlugInSupport/IMServicePlugInSupport.h>"
+

--- a/lib/osx/frameworks/ink_framework.nim
+++ b/lib/osx/frameworks/ink_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Ink".}
+const INK_FRAMEWORK_HEADER* = "<Ink/Ink.h>"
+

--- a/lib/osx/frameworks/inputmethodkit_framework.nim
+++ b/lib/osx/frameworks/inputmethodkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework InputMethodKit".}
+const INPUTMETHODKIT_FRAMEWORK_HEADER* = "<InputMethodKit/InputMethodKit.h>"
+

--- a/lib/osx/frameworks/installerplugins_framework.nim
+++ b/lib/osx/frameworks/installerplugins_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework InstallerPlugins".}
+const INSTALLERPLUGINS_FRAMEWORK_HEADER* = "<InstallerPlugins/InstallerPlugins.h>"
+

--- a/lib/osx/frameworks/instantmessage_framework.nim
+++ b/lib/osx/frameworks/instantmessage_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework InstantMessage".}
+const INSTANTMESSAGE_FRAMEWORK_HEADER* = "<InstantMessage/InstantMessage.h>"
+

--- a/lib/osx/frameworks/interfacebuilderkit_framework.nim
+++ b/lib/osx/frameworks/interfacebuilderkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework InterfaceBuilderKit".}
+const INTERFACEBUILDERKIT_FRAMEWORK_HEADER* = "<InterfaceBuilderKit/InterfaceBuilderKit.h>"
+

--- a/lib/osx/frameworks/iobluetooth_framework.nim
+++ b/lib/osx/frameworks/iobluetooth_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IOBluetooth".}
+const IOBLUETOOTH_FRAMEWORK_HEADER* = "<IOBluetooth/IOBluetooth.h>"
+

--- a/lib/osx/frameworks/iobluetoothui_framework.nim
+++ b/lib/osx/frameworks/iobluetoothui_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IOBluetoothUI".}
+const IOBLUETOOTHUI_FRAMEWORK_HEADER* = "<IOBluetoothUI/IOBluetoothUI.h>"
+

--- a/lib/osx/frameworks/iokit_framework.nim
+++ b/lib/osx/frameworks/iokit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IOKit".}
+const IOKIT_FRAMEWORK_HEADER* = "<IOKit/IOKit.h>"
+

--- a/lib/osx/frameworks/iosurface_framework.nim
+++ b/lib/osx/frameworks/iosurface_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework IOSurface".}
+const IOSURFACE_FRAMEWORK_HEADER* = "<IOSurface/IOSurface.h>"
+

--- a/lib/osx/frameworks/javaframeembedding_framework.nim
+++ b/lib/osx/frameworks/javaframeembedding_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework JavaFrameEmbedding".}
+const JAVAFRAMEEMBEDDING_FRAMEWORK_HEADER* = "<JavaFrameEmbedding/JavaFrameEmbedding.h>"
+

--- a/lib/osx/frameworks/javascriptcore_framework.nim
+++ b/lib/osx/frameworks/javascriptcore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework JavaScriptCore".}
+const JAVASCRIPTCORE_FRAMEWORK_HEADER* = "<JavaScriptCore/JavaScriptCore.h>"
+

--- a/lib/osx/frameworks/javavm_framework.nim
+++ b/lib/osx/frameworks/javavm_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework JavaVM".}
+const JAVAVM_FRAMEWORK_HEADER* = "<JavaVM/JavaVM.h>"
+

--- a/lib/osx/frameworks/kerberos_framework.nim
+++ b/lib/osx/frameworks/kerberos_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Kerberos".}
+const KERBEROS_FRAMEWORK_HEADER* = "<Kerberos/Kerberos.h>"
+

--- a/lib/osx/frameworks/kernel_framework.nim
+++ b/lib/osx/frameworks/kernel_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Kernel".}
+const KERNEL_FRAMEWORK_HEADER* = "<Kernel/Kernel.h>"
+

--- a/lib/osx/frameworks/langanalysis_framework.nim
+++ b/lib/osx/frameworks/langanalysis_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework LangAnalysis".}
+const LANGANALYSIS_FRAMEWORK_HEADER* = "<LangAnalysis/LangAnalysis.h>"
+

--- a/lib/osx/frameworks/latentsemanticmapping_framework.nim
+++ b/lib/osx/frameworks/latentsemanticmapping_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework LatentSemanticMapping".}
+const LATENTSEMANTICMAPPING_FRAMEWORK_HEADER* = "<LatentSemanticMapping/LatentSemanticMapping.h>"
+

--- a/lib/osx/frameworks/launchservices_framework.nim
+++ b/lib/osx/frameworks/launchservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework LaunchServices".}
+const LAUNCHSERVICES_FRAMEWORK_HEADER* = "<LaunchServices/LaunchServices.h>"
+

--- a/lib/osx/frameworks/ldap_framework.nim
+++ b/lib/osx/frameworks/ldap_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework LDAP".}
+const LDAP_FRAMEWORK_HEADER* = "<LDAP/LDAP.h>"
+

--- a/lib/osx/frameworks/localauthentication_framework.nim
+++ b/lib/osx/frameworks/localauthentication_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework LocalAuthentication".}
+const LOCALAUTHENTICATION_FRAMEWORK_HEADER* = "<LocalAuthentication/LocalAuthentication.h>"
+

--- a/lib/osx/frameworks/mapkit_framework.nim
+++ b/lib/osx/frameworks/mapkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework MapKit".}
+const MAPKIT_FRAMEWORK_HEADER* = "<MapKit/MapKit.h>"
+

--- a/lib/osx/frameworks/mediaaccessibility_framework.nim
+++ b/lib/osx/frameworks/mediaaccessibility_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework MediaAccessibility".}
+const MEDIAACCESSIBILITY_FRAMEWORK_HEADER* = "<MediaAccessibility/MediaAccessibility.h>"
+

--- a/lib/osx/frameworks/mediabrowser_framework.nim
+++ b/lib/osx/frameworks/mediabrowser_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework MediaBrowser".}
+const MEDIABROWSER_FRAMEWORK_HEADER* = "<MediaBrowser/MediaBrowser.h>"
+

--- a/lib/osx/frameworks/medialibrary_framework.nim
+++ b/lib/osx/frameworks/medialibrary_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework MediaLibrary".}
+const MEDIALIBRARY_FRAMEWORK_HEADER* = "<MediaLibrary/MediaLibrary.h>"
+

--- a/lib/osx/frameworks/message_framework.nim
+++ b/lib/osx/frameworks/message_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Message".}
+const MESSAGE_FRAMEWORK_HEADER* = "<Message/Message.h>"
+

--- a/lib/osx/frameworks/metadata_framework.nim
+++ b/lib/osx/frameworks/metadata_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Metadata".}
+const METADATA_FRAMEWORK_HEADER* = "<Metadata/Metadata.h>"
+

--- a/lib/osx/frameworks/multipeerconnectivity_framework.nim
+++ b/lib/osx/frameworks/multipeerconnectivity_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework MultipeerConnectivity".}
+const MULTIPEERCONNECTIVITY_FRAMEWORK_HEADER* = "<MultipeerConnectivity/MultipeerConnectivity.h>"
+

--- a/lib/osx/frameworks/navigationservices_framework.nim
+++ b/lib/osx/frameworks/navigationservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework NavigationServices".}
+const NAVIGATIONSERVICES_FRAMEWORK_HEADER* = "<NavigationServices/NavigationServices.h>"
+

--- a/lib/osx/frameworks/netfs_framework.nim
+++ b/lib/osx/frameworks/netfs_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework NetFS".}
+const NETFS_FRAMEWORK_HEADER* = "<NetFS/NetFS.h>"
+

--- a/lib/osx/frameworks/notificationcenter_framework.nim
+++ b/lib/osx/frameworks/notificationcenter_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework NotificationCenter".}
+const NOTIFICATIONCENTER_FRAMEWORK_HEADER* = "<NotificationCenter/NotificationCenter.h>"
+

--- a/lib/osx/frameworks/openal_framework.nim
+++ b/lib/osx/frameworks/openal_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OpenAL".}
+const OPENAL_FRAMEWORK_HEADER* = "<OpenAL/OpenAL.h>"
+

--- a/lib/osx/frameworks/opencl_framework.nim
+++ b/lib/osx/frameworks/opencl_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OpenCL".}
+const OPENCL_FRAMEWORK_HEADER* = "<OpenCL/OpenCL.h>"
+

--- a/lib/osx/frameworks/opendirectory_framework.nim
+++ b/lib/osx/frameworks/opendirectory_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OpenDirectory".}
+const OPENDIRECTORY_FRAMEWORK_HEADER* = "<OpenDirectory/OpenDirectory.h>"
+

--- a/lib/osx/frameworks/opengl_framework.nim
+++ b/lib/osx/frameworks/opengl_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OpenGL".}
+const OPENGL_FRAMEWORK_HEADER* = "<OpenGL/OpenGL.h>"
+

--- a/lib/osx/frameworks/openscripting_framework.nim
+++ b/lib/osx/frameworks/openscripting_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OpenScripting".}
+const OPENSCRIPTING_FRAMEWORK_HEADER* = "<OpenScripting/OpenScripting.h>"
+

--- a/lib/osx/frameworks/osakit_framework.nim
+++ b/lib/osx/frameworks/osakit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OSAKit".}
+const OSAKIT_FRAMEWORK_HEADER* = "<OSAKit/OSAKit.h>"
+

--- a/lib/osx/frameworks/osservices_framework.nim
+++ b/lib/osx/frameworks/osservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework OSServices".}
+const OSSERVICES_FRAMEWORK_HEADER* = "<OSServices/OSServices.h>"
+

--- a/lib/osx/frameworks/pcsc_framework.nim
+++ b/lib/osx/frameworks/pcsc_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework PCSC".}
+const PCSC_FRAMEWORK_HEADER* = "<PCSC/PCSC.h>"
+

--- a/lib/osx/frameworks/pdfkit_framework.nim
+++ b/lib/osx/frameworks/pdfkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework PDFKit".}
+const PDFKIT_FRAMEWORK_HEADER* = "<PDFKit/PDFKit.h>"
+

--- a/lib/osx/frameworks/preferencepanes_framework.nim
+++ b/lib/osx/frameworks/preferencepanes_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework PreferencePanes".}
+const PREFERENCEPANES_FRAMEWORK_HEADER* = "<PreferencePanes/PreferencePanes.h>"
+

--- a/lib/osx/frameworks/print_framework.nim
+++ b/lib/osx/frameworks/print_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Print".}
+const PRINT_FRAMEWORK_HEADER* = "<Print/Print.h>"
+

--- a/lib/osx/frameworks/printcore_framework.nim
+++ b/lib/osx/frameworks/printcore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework PrintCore".}
+const PRINTCORE_FRAMEWORK_HEADER* = "<PrintCore/PrintCore.h>"
+

--- a/lib/osx/frameworks/pubsub_framework.nim
+++ b/lib/osx/frameworks/pubsub_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework PubSub".}
+const PUBSUB_FRAMEWORK_HEADER* = "<PubSub/PubSub.h>"
+

--- a/lib/osx/frameworks/qd_framework.nim
+++ b/lib/osx/frameworks/qd_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QD".}
+const QD_FRAMEWORK_HEADER* = "<QD/QD.h>"
+

--- a/lib/osx/frameworks/qtkit_framework.nim
+++ b/lib/osx/frameworks/qtkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QTKit".}
+const QTKIT_FRAMEWORK_HEADER* = "<QTKit/QTKit.h>"
+

--- a/lib/osx/frameworks/quartz_framework.nim
+++ b/lib/osx/frameworks/quartz_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Quartz".}
+const QUARTZ_FRAMEWORK_HEADER* = "<Quartz/Quartz.h>"
+

--- a/lib/osx/frameworks/quartzcomposer_framework.nim
+++ b/lib/osx/frameworks/quartzcomposer_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuartzComposer".}
+const QUARTZCOMPOSER_FRAMEWORK_HEADER* = "<QuartzComposer/QuartzComposer.h>"
+

--- a/lib/osx/frameworks/quartzcore_framework.nim
+++ b/lib/osx/frameworks/quartzcore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuartzCore".}
+const QUARTZCORE_FRAMEWORK_HEADER* = "<QuartzCore/QuartzCore.h>"
+

--- a/lib/osx/frameworks/quartzfilters_framework.nim
+++ b/lib/osx/frameworks/quartzfilters_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuartzFilters".}
+const QUARTZFILTERS_FRAMEWORK_HEADER* = "<QuartzFilters/QuartzFilters.h>"
+

--- a/lib/osx/frameworks/quicklook_framework.nim
+++ b/lib/osx/frameworks/quicklook_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuickLook".}
+const QUICKLOOK_FRAMEWORK_HEADER* = "<QuickLook/QuickLook.h>"
+

--- a/lib/osx/frameworks/quicklookui_framework.nim
+++ b/lib/osx/frameworks/quicklookui_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuickLookUI".}
+const QUICKLOOKUI_FRAMEWORK_HEADER* = "<QuickLookUI/QuickLookUI.h>"
+

--- a/lib/osx/frameworks/quicktime_framework.nim
+++ b/lib/osx/frameworks/quicktime_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework QuickTime".}
+const QUICKTIME_FRAMEWORK_HEADER* = "<QuickTime/QuickTime.h>"
+

--- a/lib/osx/frameworks/ruby_framework.nim
+++ b/lib/osx/frameworks/ruby_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Ruby".}
+const RUBY_FRAMEWORK_HEADER* = "<Ruby/Ruby.h>"
+

--- a/lib/osx/frameworks/scenekit_framework.nim
+++ b/lib/osx/frameworks/scenekit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SceneKit".}
+const SCENEKIT_FRAMEWORK_HEADER* = "<SceneKit/SceneKit.h>"
+

--- a/lib/osx/frameworks/screensaver_framework.nim
+++ b/lib/osx/frameworks/screensaver_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ScreenSaver".}
+const SCREENSAVER_FRAMEWORK_HEADER* = "<ScreenSaver/ScreenSaver.h>"
+

--- a/lib/osx/frameworks/scripting_framework.nim
+++ b/lib/osx/frameworks/scripting_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Scripting".}
+const SCRIPTING_FRAMEWORK_HEADER* = "<Scripting/Scripting.h>"
+

--- a/lib/osx/frameworks/scriptingbridge_framework.nim
+++ b/lib/osx/frameworks/scriptingbridge_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ScriptingBridge".}
+const SCRIPTINGBRIDGE_FRAMEWORK_HEADER* = "<ScriptingBridge/ScriptingBridge.h>"
+

--- a/lib/osx/frameworks/searchkit_framework.nim
+++ b/lib/osx/frameworks/searchkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SearchKit".}
+const SEARCHKIT_FRAMEWORK_HEADER* = "<SearchKit/SearchKit.h>"
+

--- a/lib/osx/frameworks/security_framework.nim
+++ b/lib/osx/frameworks/security_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Security".}
+const SECURITY_FRAMEWORK_HEADER* = "<Security/Security.h>"
+

--- a/lib/osx/frameworks/securityfoundation_framework.nim
+++ b/lib/osx/frameworks/securityfoundation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SecurityFoundation".}
+const SECURITYFOUNDATION_FRAMEWORK_HEADER* = "<SecurityFoundation/SecurityFoundation.h>"
+

--- a/lib/osx/frameworks/securityhi_framework.nim
+++ b/lib/osx/frameworks/securityhi_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SecurityHI".}
+const SECURITYHI_FRAMEWORK_HEADER* = "<SecurityHI/SecurityHI.h>"
+

--- a/lib/osx/frameworks/securityinterface_framework.nim
+++ b/lib/osx/frameworks/securityinterface_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SecurityInterface".}
+const SECURITYINTERFACE_FRAMEWORK_HEADER* = "<SecurityInterface/SecurityInterface.h>"
+

--- a/lib/osx/frameworks/sentestingkit_framework.nim
+++ b/lib/osx/frameworks/sentestingkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SenTestingKit".}
+const SENTESTINGKIT_FRAMEWORK_HEADER* = "<SenTestingKit/SenTestingKit.h>"
+

--- a/lib/osx/frameworks/servicemanagement_framework.nim
+++ b/lib/osx/frameworks/servicemanagement_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework ServiceManagement".}
+const SERVICEMANAGEMENT_FRAMEWORK_HEADER* = "<ServiceManagement/ServiceManagement.h>"
+

--- a/lib/osx/frameworks/social_framework.nim
+++ b/lib/osx/frameworks/social_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Social".}
+const SOCIAL_FRAMEWORK_HEADER* = "<Social/Social.h>"
+

--- a/lib/osx/frameworks/speechrecognition_framework.nim
+++ b/lib/osx/frameworks/speechrecognition_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SpeechRecognition".}
+const SPEECHRECOGNITION_FRAMEWORK_HEADER* = "<SpeechRecognition/SpeechRecognition.h>"
+

--- a/lib/osx/frameworks/speechsynthesis_framework.nim
+++ b/lib/osx/frameworks/speechsynthesis_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SpeechSynthesis".}
+const SPEECHSYNTHESIS_FRAMEWORK_HEADER* = "<SpeechSynthesis/SpeechSynthesis.h>"
+

--- a/lib/osx/frameworks/spritekit_framework.nim
+++ b/lib/osx/frameworks/spritekit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SpriteKit".}
+const SPRITEKIT_FRAMEWORK_HEADER* = "<SpriteKit/SpriteKit.h>"
+

--- a/lib/osx/frameworks/storekit_framework.nim
+++ b/lib/osx/frameworks/storekit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework StoreKit".}
+const STOREKIT_FRAMEWORK_HEADER* = "<StoreKit/StoreKit.h>"
+

--- a/lib/osx/frameworks/syncservices_framework.nim
+++ b/lib/osx/frameworks/syncservices_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SyncServices".}
+const SYNCSERVICES_FRAMEWORK_HEADER* = "<SyncServices/SyncServices.h>"
+

--- a/lib/osx/frameworks/system_framework.nim
+++ b/lib/osx/frameworks/system_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework System".}
+const SYSTEM_FRAMEWORK_HEADER* = "<System/System.h>"
+

--- a/lib/osx/frameworks/systemconfiguration_framework.nim
+++ b/lib/osx/frameworks/systemconfiguration_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework SystemConfiguration".}
+const SYSTEMCONFIGURATION_FRAMEWORK_HEADER* = "<SystemConfiguration/SystemConfiguration.h>"
+

--- a/lib/osx/frameworks/tcl_framework.nim
+++ b/lib/osx/frameworks/tcl_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Tcl".}
+const TCL_FRAMEWORK_HEADER* = "<Tcl/Tcl.h>"
+

--- a/lib/osx/frameworks/tk_framework.nim
+++ b/lib/osx/frameworks/tk_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework Tk".}
+const TK_FRAMEWORK_HEADER* = "<Tk/Tk.h>"
+

--- a/lib/osx/frameworks/twain_framework.nim
+++ b/lib/osx/frameworks/twain_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework TWAIN".}
+const TWAIN_FRAMEWORK_HEADER* = "<TWAIN/TWAIN.h>"
+

--- a/lib/osx/frameworks/veclib_framework.nim
+++ b/lib/osx/frameworks/veclib_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework vecLib".}
+const VECLIB_FRAMEWORK_HEADER* = "<vecLib/vecLib.h>"
+

--- a/lib/osx/frameworks/videodecodeacceleration_framework.nim
+++ b/lib/osx/frameworks/videodecodeacceleration_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework VideoDecodeAcceleration".}
+const VIDEODECODEACCELERATION_FRAMEWORK_HEADER* = "<VideoDecodeAcceleration/VideoDecodeAcceleration.h>"
+

--- a/lib/osx/frameworks/videotoolbox_framework.nim
+++ b/lib/osx/frameworks/videotoolbox_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework VideoToolbox".}
+const VIDEOTOOLBOX_FRAMEWORK_HEADER* = "<VideoToolbox/VideoToolbox.h>"
+

--- a/lib/osx/frameworks/vimage_framework.nim
+++ b/lib/osx/frameworks/vimage_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework vImage".}
+const VIMAGE_FRAMEWORK_HEADER* = "<vImage/vImage.h>"
+

--- a/lib/osx/frameworks/webcore_framework.nim
+++ b/lib/osx/frameworks/webcore_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework WebCore".}
+const WEBCORE_FRAMEWORK_HEADER* = "<WebCore/WebCore.h>"
+

--- a/lib/osx/frameworks/webkit_framework.nim
+++ b/lib/osx/frameworks/webkit_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework WebKit".}
+const WEBKIT_FRAMEWORK_HEADER* = "<WebKit/WebKit.h>"
+

--- a/lib/osx/frameworks/xctest_framework.nim
+++ b/lib/osx/frameworks/xctest_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework XCTest".}
+const XCTEST_FRAMEWORK_HEADER* = "<XCTest/XCTest.h>"
+

--- a/lib/osx/frameworks/xgridfoundation_framework.nim
+++ b/lib/osx/frameworks/xgridfoundation_framework.nim
@@ -1,0 +1,3 @@
+{.passL: "-framework XgridFoundation".}
+const XGRIDFOUNDATION_FRAMEWORK_HEADER* = "<XgridFoundation/XgridFoundation.h>"
+


### PR DESCRIPTION
Thanks to Nim's support for C and Objective-C FFI, Nim can wrap OS X's system frameworks. This commit adds stub files for the system frameworks that come with every OS X installation. The whole point of these is to abstract away the linker flags and header locations for each framework.