### PR TITLE
Always use 0x40 for POSIX_SPAWN_USEVFORK

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -1732,12 +1732,10 @@ when hasSpawnH:
   when defined(linux):
     # better be safe than sorry; Linux has this flag, macosx doesn't, don't
     # know about the other OSes
-    when defined(tcc):
-      # TCC doesn't define __USE_GNU, so we can't get the magic number from
-      # spawn.h
-      const POSIX_SPAWN_USEVFORK* = cint(0x40)
-    else:
-      var POSIX_SPAWN_USEVFORK* {.importc, header: "<spawn.h>".}: cint
+
+    # Non-GNU systems like TCC and musl-libc  don't define __USE_GNU, so we
+    # can't get the magic number from spawn.h
+    const POSIX_SPAWN_USEVFORK* = cint(0x40)
   else:
     # macosx lacks this, so we define the constant to be 0 to not affect
     # OR'ing of flags:


### PR DESCRIPTION
```
02:27 < pogoplug> I'm having problems bootstraping nim on Ansible linux.  I get the following error: 
                  "nimcache/stdlib_osproc.c:1628:57: error: use of undeclared identifier 
                  'POSIX_SPAWN_USEVFORK'                 LOC33 = posix_spawnattr_setflags(&attr, 
                  (NI32)((NI32)(POSIX_SPAWN_US..."
02:28 < def-> pogoplug: with which C compiler?
02:28 < pogoplug> clang
02:28 < pogoplug> and musl-libc
02:29 < def-> ok, that explains it
02:29 < pogoplug> not to me
02:30 < def-> https://github.com/Araq/Nim/blob/devel/lib/posix/posix.nim#L1732-L1744
02:30 < def-> I noticed the same issue with TCC and added this workaround
02:31 < def-> I guess we need it in a more general way
```
Is there a way to detect whether we have `__USE_GNU` or `POSIX_SPAWN_USEVFORK` from `<spawn.h` directly?