### PR TITLE
Fixing toHex() to not wrap for long lens + Test

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -395,11 +395,13 @@ proc toHex*(x: BiggestInt, len: int): string {.noSideEffect,
   const
     HexChars = "0123456789ABCDEF"
   var
-    shift: BiggestInt
+    n = x
   result = newString(len)
   for j in countdown(len-1, 0):
-    result[j] = HexChars[toU32(x shr shift) and 0xF'i32]
-    shift = shift + 4
+    result[j] = HexChars[n and 0xF]
+    n = n shr 4
+    # handle negative overflow
+    if n == 0 and x < 0: n = -1
 
 proc intToStr*(x: int, minchars: int = 1): string {.noSideEffect,
   rtl, extern: "nsuIntToStr".} =

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -43,6 +43,9 @@ assert "/1/2/3".rfind('/') == 4
 assert "/1/2/3".rfind('/', 1) == 0
 assert "/1/2/3".rfind('0') == -1
 
+assert(toHex(100i16, 32) == "00000000000000000000000000000064")
+assert(toHex(-100i16, 32) == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9C")
+
 main()
 #OUT ha/home/a1xyz/usr/bin
 


### PR DESCRIPTION
If you specify a len like 32 toHex() will repeat the given value in the output. Besides that I believe my implementation is easier and seems not
to change how negative numbers are handled. I also handle the case of wrapping negative number beyond BiggestInt to "do it right".

P.S.: I am not sure why there was the toU32() in the original. I have no problems compiling it without that?