### PR TITLE
Change defined(mac) to defined(macosx)

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -107,7 +107,7 @@ elif defined(windows) or defined(dos):
     result = getProcAddress(cast[THINSTANCE](lib), name)
     if result == nil: procAddrError(name)
 
-elif defined(mac):
+elif defined(macosx):
   #
   # =======================================================================
   # Native Mac OS X / Darwin Implementation


### PR DESCRIPTION
I believe `defined(mac)` does not even work.