### PR TITLE
sorted & sortByIt

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -187,6 +187,13 @@ proc sort*[T](a: var openArray[T],
       dec(m, s*2)
     s = s*2
 
+proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.}, order = SortOrder.Ascending): seq[T] =
+  ## returns `a` sorted by `cmp` in the specified `order`.
+  result = newSeq[T](a.len)
+  for i in 0 .. a.high:
+    result[i] = a[i]
+  sort(result, cmp, order)
+
 proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
   ## produces the Cartesian product of the array. Warning: complexity
   ## may explode.

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -194,6 +194,27 @@ proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.}, order = So
     result[i] = a[i]
   sort(result, cmp, order)
 
+template sortByIt*(seq1, op: expr): expr =
+  ## Convenience template around the ``sorted`` proc to reduce typing.
+  ##
+  ## The template injects the ``it`` variable which you can use directly in an
+  ## expression. Example:
+  ##
+  ## .. code-block:: nim
+  ##
+  ##     var users: seq[tuple[id: int, name: string]] =
+  ##       @[(0, "Smith"), (1, "Pratt"), (2, "Sparrow")]
+  ##
+  ##     echo users.sortByIt(it.name)
+  ##
+  var result {.gensym.} = sorted(seq1, proc(x, y: type(seq1[0])): int =
+    var it {.inject.} = x
+    let a = op
+    it = y
+    let b = op
+    result = cmp(a, b))
+  result
+
 proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
   ## produces the Cartesian product of the array. Warning: complexity
   ## may explode.

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -26,8 +26,6 @@
 when not defined(nimhygiene):
   {.pragma: dirty.}
 
-import algorithm
-
 proc concat*[T](seqs: varargs[seq[T]]): seq[T] =
   ## Takes several sequences' items and returns them inside a new sequence.
   ##
@@ -416,19 +414,6 @@ template mapIt*(varSeq, op: expr) =
   for i in 0 .. <len(varSeq):
     let it {.inject.} = varSeq[i]
     varSeq[i] = op
-
-template sortByIt*(seq1, op: expr): expr =
-  ## Convenience template around the ``sorted`` proc to reduce typing.
-  ##
-  ## The template injects the ``it`` variable which you can use directly in an
-  ## expression.
-  var result {.gensym.} = sorted(seq1, proc(x, y: type(seq1[0])): int =
-    var it {.inject.} = x
-    let a = op
-    it = y
-    let b = op
-    result = cmp(a, b))
-  result
 
 template newSeqWith*(len: int, init: expr): expr =
   ## creates a new sequence, calling `init` to initialize each value. Example:

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -417,7 +417,7 @@ template mapIt*(varSeq, op: expr) =
     let it {.inject.} = varSeq[i]
     varSeq[i] = op
 
-template sortedBy*(seq1, op: expr): expr =
+template sortByIt*(seq1, op: expr): expr =
   ## Convenience template around the ``sorted`` proc to reduce typing.
   ##
   ## The template injects the ``it`` variable which you can use directly in an

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -26,6 +26,8 @@
 when not defined(nimhygiene):
   {.pragma: dirty.}
 
+import algorithm
+
 proc concat*[T](seqs: varargs[seq[T]]): seq[T] =
   ## Takes several sequences' items and returns them inside a new sequence.
   ##
@@ -414,6 +416,19 @@ template mapIt*(varSeq, op: expr) =
   for i in 0 .. <len(varSeq):
     let it {.inject.} = varSeq[i]
     varSeq[i] = op
+
+template sortedBy*(seq1, op: expr): expr =
+  ## Convenience template around the ``sorted`` proc to reduce typing.
+  ##
+  ## The template injects the ``it`` variable which you can use directly in an
+  ## expression.
+  var result {.gensym.} = sorted(seq1, proc(x, y: type(seq1[0])): int =
+    var it {.inject.} = x
+    let a = op
+    it = y
+    let b = op
+    result = cmp(a, b))
+  result
 
 template newSeqWith*(len: int, init: expr): expr =
   ## creates a new sequence, calling `init` to initialize each value. Example:


### PR DESCRIPTION
dom96 said we should care a bit more about functional programming before 1.0.

So I tried to reimplement the top example from here: http://www.vasinov.com/blog/16-months-of-functional-programming/

This is the final code:
```nim
import sequtils

type User = tuple[id: int, firstName, lastName: string, active: bool]

proc activeById(us: seq[User]): seq[string] =
  us.filterIt(it.active).sortedBy(it.id).mapIt(string, it.lastName)

let activeUsersById = activeById(@[
  (11, "Nick", "Smith", false),
  (89, "Ken", "Pratt", true),
  (23, "Jack", "Sparrow", true)
])

echo activeUsersById
```

If this code is actually wanted I can extend the documentation and add examples of usage.

It's also quite unfortunate that we even need the `mapIt` and related templates. Would be much nicer if instead we could do `.map(x => x.lastName)` instead of the more unwiedy `.map((x: User) -> string => x.lastName)`.