### PR TITLE
Allow empty sets in case/of branches.

### DIFF
--- a/tests/casestmt/tcase_emptyset_when.nim
+++ b/tests/casestmt/tcase_emptyset_when.nim
@@ -1,0 +1,24 @@
+discard """
+  file: "tcaseofwhen.nim"
+  outputsub: "compiles for 1\ni am always two\ndefault for 3\nset is 4 not 5\narray is 6 not 7\ndefault for 8"
+  exitcode: "0"
+"""
+
+proc whenCase(a: int) =
+  case a
+  of (when compiles(whenCase(1)): 1 else: {}): echo "compiles for 1"
+  of {}: echo "me not fail"
+  of 2: echo "i am always two"
+  of []: echo "me neither"
+  of {4,5}: echo "set is 4 not 5"
+  of [6,7]: echo "array is 6 not 7"
+  of (when compiles(neverCompilesIBet()): 3 else: {}): echo "compiles for 3"
+  #of {},[]: echo "me neither"
+  else: echo "default for ", a
+
+whenCase(1)
+whenCase(2)
+whenCase(3)
+whenCase(4)
+whenCase(6)
+whenCase(8)


### PR DESCRIPTION
Added support for conditional compilation using 'when' with empty sets in 'case of' branches.

Added test category for conditional compilation. Test with `./koch test c conditional`. I think this could be continued with other "when" related code, like in objects or for example if supported in enums.

This was discussed in the forum http://forum.nim-lang.org/t/867 ...

@Araq: Even if that won't be a correct & final solution it seems to work and I am so happy that I could create it :)