### PR TITLE
Macro for parseEnum

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1363,13 +1363,17 @@ proc parseEnum*[T: enum](s: string): T =
   ## Raises ``ValueError`` for an invalid value in `s`. The comparison is
   ## done in a style insensitive way.
   macro m: stmt =
-    result = newStmtList()
+    result = newNimNode(nnkCaseStmt).add(newDotExpr(newIdentNode("s"),
+      newIdentNode("normalize")))
 
-    for e in T: result.add parseStmt(
-      "if cmpIgnoreStyle(s, \"$1\") == 0: return $1".format(e))
+    for e in T:
+      result.add(newNimNode(nnkOfBranch).add(newStrLitNode(($e).normalize),
+        newNimNode(nnkReturnStmt).add(newIdentNode($e))))
 
-    result.add parseStmt(
-      "raise newException(ValueError, \"invalid enum value: \" & s)")
+    result.add(newNimNode(nnkElse).add(newNimNode(nnkRaiseStmt).add(newCall(
+      newIdentNode("newException"), newIdentNode("ValueError"),
+      newNimNode(nnkInfix).add(newIdentNode("&"),
+        newStrLitNode("invalid enum value: "), newIdentNode("s"))))))
 
   m()
 
@@ -1379,12 +1383,15 @@ proc parseEnum*[T: enum](s: string, default: T): T =
   ## Uses `default` for an invalid value in `s`. The comparison is done in a
   ## style insensitive way.
   macro m: stmt =
-    result = newStmtList()
+    result = newNimNode(nnkCaseStmt).add(newDotExpr(newIdentNode("s"),
+      newIdentNode("normalize")))
 
-    for e in T: result.add parseStmt(
-      "if cmpIgnoreStyle(s, \"$1\") == 0: return $1".format(e))
+    for e in T:
+      result.add(newNimNode(nnkOfBranch).add(newStrLitNode(($e).normalize),
+        newNimNode(nnkReturnStmt).add(newIdentNode($e))))
 
-    result.add parseStmt("result = default")
+    result.add(newNimNode(nnkElse).add(newAssignment(newIdentNode("result"),
+      newIdentNode("default"))))
 
   m()
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -479,26 +479,6 @@ proc parseBool*(s: string): bool =
   of "n", "no", "false", "0", "off": result = false
   else: raise newException(ValueError, "cannot interpret as a bool: " & s)
 
-proc parseEnum*[T: enum](s: string): T =
-  ## Parses an enum ``T``.
-  ##
-  ## Raises ``ValueError`` for an invalid value in `s`. The comparison is
-  ## done in a style insensitive way.
-  for e in low(T)..high(T):
-    if cmpIgnoreStyle(s, $e) == 0:
-      return e
-  raise newException(ValueError, "invalid enum value: " & s)
-
-proc parseEnum*[T: enum](s: string, default: T): T =
-  ## Parses an enum ``T``.
-  ##
-  ## Uses `default` for an invalid value in `s`. The comparison is done in a
-  ## style insensitive way.
-  for e in low(T)..high(T):
-    if cmpIgnoreStyle(s, $e) == 0:
-      return e
-  result = default
-
 proc repeatChar*(count: int, c: char = ' '): string {.noSideEffect,
   rtl, extern: "nsuRepeatChar".} =
   ## Returns a string of length `count` consisting only of
@@ -1373,6 +1353,52 @@ proc format*(formatstr: string, a: varargs[string, `$`]): string {.noSideEffect,
   ## auto stringification.
   result = newStringOfCap(formatstr.len + a.len)
   addf(result, formatstr, a)
+
+# Moved down here because the macros module requires cmpIgnoreStyle and format
+import macros
+
+proc parseEnum*[T: enum](s: string): T =
+  ## Parses an enum ``T``.
+  ##
+  ## Raises ``ValueError`` for an invalid value in `s`. The comparison is
+  ## done in a style insensitive way.
+  macro m: stmt =
+    result = newStmtList()
+
+    for e in T:
+      # if cmpIgnoreStyle(s, $e) == 0: return e
+      result.add(newIfStmt((newNimNode(nnkInfix).add(newIdentNode("=="),
+        newCall(newIdentNode("cmpIgnoreStyle"), newIdentNode("s"),
+          newStrLitNode($e)), newIntLitNode(0)),
+        newNimNode(nnkReturnStmt).add(newIdentNode($e)))))
+
+    # raise newException(ValueError, "invalid enum value: " & s)
+    result.add(newNimNode(nnkRaiseStmt).add(newCall(
+      newIdentNode("newException"), newIdentNode("ValueError"),
+      newNimNode(nnkInfix).add(newIdentNode("&"),
+        newStrLitNode("invalid enum value: "), newIdentNode("s")))))
+
+  m()
+
+proc parseEnum*[T: enum](s: string, default: T): T =
+  ## Parses an enum ``T``.
+  ##
+  ## Uses `default` for an invalid value in `s`. The comparison is done in a
+  ## style insensitive way.
+  macro m: stmt =
+    result = newStmtList()
+
+    for e in T:
+      # if cmpIgnoreStyle(s, $e) == 0: return e
+      result.add(newIfStmt((newNimNode(nnkInfix).add(newIdentNode("=="),
+        newCall(newIdentNode("cmpIgnoreStyle"), newIdentNode("s"),
+          newStrLitNode($e)), newIntLitNode(0)),
+        newNimNode(nnkReturnStmt).add(newIdentNode($e)))))
+
+    # result = default
+    result.add(newAssignment(newIdentNode("result"), newIdentNode("default")))
+
+  m()
 
 {.pop.}
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1365,18 +1365,11 @@ proc parseEnum*[T: enum](s: string): T =
   macro m: stmt =
     result = newStmtList()
 
-    for e in T:
-      # if cmpIgnoreStyle(s, $e) == 0: return e
-      result.add(newIfStmt((newNimNode(nnkInfix).add(newIdentNode("=="),
-        newCall(newIdentNode("cmpIgnoreStyle"), newIdentNode("s"),
-          newStrLitNode($e)), newIntLitNode(0)),
-        newNimNode(nnkReturnStmt).add(newIdentNode($e)))))
+    for e in T: result.add parseStmt(
+      "if cmpIgnoreStyle(s, \"$1\") == 0: return $1".format(e))
 
-    # raise newException(ValueError, "invalid enum value: " & s)
-    result.add(newNimNode(nnkRaiseStmt).add(newCall(
-      newIdentNode("newException"), newIdentNode("ValueError"),
-      newNimNode(nnkInfix).add(newIdentNode("&"),
-        newStrLitNode("invalid enum value: "), newIdentNode("s")))))
+    result.add parseStmt(
+      "raise newException(ValueError, \"invalid enum value: \" & s)")
 
   m()
 
@@ -1388,15 +1381,10 @@ proc parseEnum*[T: enum](s: string, default: T): T =
   macro m: stmt =
     result = newStmtList()
 
-    for e in T:
-      # if cmpIgnoreStyle(s, $e) == 0: return e
-      result.add(newIfStmt((newNimNode(nnkInfix).add(newIdentNode("=="),
-        newCall(newIdentNode("cmpIgnoreStyle"), newIdentNode("s"),
-          newStrLitNode($e)), newIntLitNode(0)),
-        newNimNode(nnkReturnStmt).add(newIdentNode($e)))))
+    for e in T: result.add parseStmt(
+      "if cmpIgnoreStyle(s, \"$1\") == 0: return $1".format(e))
 
-    # result = default
-    result.add(newAssignment(newIdentNode("result"), newIdentNode("default")))
+    result.add parseStmt("result = default")
 
   m()
 


### PR DESCRIPTION
Optimize parseEnum
    
- Uses a macro to create the proc at compile time.
- Speeds up parseEnum about 8 times in my experiments.

Use nicer and more compact parseStmt()
    
- This creates many strings at compile time, so I was hesitant at first
- After testing it doesn't seem to cause any measurable slowdown

I'm wondering if I could move the macros outside of the proc, but didn't succeed.