### PR TITLE
Allow ranges with unsigned integer ordinals to be used as parameter types

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1100,7 +1100,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     result = typeAllowedAux(marker, lastSon(t), kind, flags)
   of tyRange:
     if skipTypes(t.sons[0], abstractInst-{tyTypeDesc}).kind notin
-        {tyChar, tyEnum, tyInt..tyFloat128}: result = t
+        {tyChar, tyEnum, tyInt..tyFloat128, tyUInt8..tyUInt32}: result = t
   of tyOpenArray, tyVarargs:
     if kind != skParam: result = t
     else: result = typeAllowedAux(marker, t.sons[0], skVar, flags)


### PR DESCRIPTION
This fix allows the following code to work:
```
import unsigned
type UInt32Range = range[5'u32..15'u32]
  
proc square(n: UInt32Range): uint32 =
  result = n * n

echo square(2'u32)
```

Without the fix, the compiler throws a compilation error, stating:
```
Error: invalid type: 'UInt32Range' in this context: 'proc (UInt32Range): uint32`
```