### PR TITLE
Made nimsuggest compilation independent from module path order.

### DIFF
--- a/compiler/nimsuggest/nimsuggest.nim
+++ b/compiler/nimsuggest/nimsuggest.nim
@@ -9,9 +9,12 @@
 
 ## Nimsuggest is a tool that helps to give editors IDE like capabilities.
 
-import strutils, os, parseopt, parseUtils
-import options, commands, modules, sem, passes, passaux, msgs, nimconf,
-  extccomp, condsyms, lists, net, rdstdin
+import strutils, os, parseopt, parseUtils, net, rdstdin
+
+# These are all part of the compiler sources
+import compiler.options, compiler.commands, compiler.modules, compiler.sem,
+  compiler.passes, compiler.passaux, compiler.msgs, compiler.nimconf,
+  compiler.extccomp, compiler.condsyms, compiler.lists
 
 const Usage = """
 Nimsuggest - Tool to give every editor IDE like capabilities for Nim


### PR DESCRIPTION
Compilation of nimsuggest could easily fail if `lib/pure/collections/lists.nim` was found before `compiler/lists.nim` (I think the names need to be changed). As the local project path points into the Nim compiler root folder I think modifing the module paths to prefix with `compiler.foobar` gives some safety. Additionally I clustered the compiler dependencies and added a comment.