### PR TITLE
Corrected SYSTEM_INFO structure to match pointer type on 64-bit systems

### DIFF
--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -11616,7 +11616,7 @@ type
     dwPageSize*: DWORD
     lpMinimumApplicationAddress*: LPVOID
     lpMaximumApplicationAddress*: LPVOID
-    dwActiveProcessorMask*: DWORD
+    dwActiveProcessorMask*: DWORD_PTR
     dwNumberOfProcessors*: DWORD
     dwProcessorType*: DWORD
     dwAllocationGranularity*: DWORD


### PR DESCRIPTION
This should correct the issue regarding member size on 64-bit systems. The MinGW header winbase.h is not quite right. `dwActiveProcessorMask` should be `DWORD_PTR` instead of `DWORD` as per https://msdn.microsoft.com/en-us/library/windows/desktop/ms724958%28v=vs.85%29.aspx