### PR TITLE
Fix for compiler not building anymore since #c3244ef1ff

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -738,7 +738,9 @@ proc peekChar(socket: Socket, c: var char): int {.tags: [ReadIOEffect].} =
         return
     result = recv(socket.fd, addr(c), 1, MSG_PEEK)
 
-import winlean
+when not defined(macosx):
+  import winlean
+
 proc readLine*(socket: Socket, line: var TaintedString, timeout = -1,
                flags = {SocketFlag.SafeDisconn}) {.
   tags: [ReadIOEffect, TimeEffect].} =


### PR DESCRIPTION
Since "winlean" is imported I can't build the compiler anymore (it
complains about missing TUtf16Char / useWinUnicode