### PR TITLE
Fix for timer overflow when using nimprofiler with 32bit Windows target.

### DIFF
--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -132,7 +132,7 @@ else:
   proc hook(st: TStackTrace) {.nimcall.} =
     if interval == 0:
       hookAux(st, 1)
-    elif getTicks() - t0 > interval:
+    elif int64(t0) == 0 or getTicks() - t0 > interval:
       hookAux(st, 1)
       t0 = getTicks()
 

--- a/lib/system/timers.nim
+++ b/lib/system/timers.nim
@@ -27,9 +27,9 @@ when defined(windows):
   proc `-`(a, b: TTicks): TNanos =
     var frequency: int64
     QueryPerformanceFrequency(frequency)
-    var performanceCounterRate = 1000000000.0 / toFloat(frequency.int)
+    var performanceCounterRate = 1e+9'f64 / float64(frequency)
 
-    result = ((a.int64 - b.int64).int.toFloat * performanceCounterRate).TNanos
+    result = TNanos(float64(a.int64 - b.int64) * performanceCounterRate)
 
 elif defined(macosx):
   type


### PR DESCRIPTION
Had a program exit with the following trace after compiling in the nim profiler:

```
units.nim                nodim
nimprof.nim(135)         hook
timers.nim(32)           -
Error: unhandled exception: value out of range: 474666261244 [RangeError]
```

It's a 32 bit compile target, so the casts `timers.-(a, b: TTicks) : TNanos` was performing was narrowing from int64 -> int32.  I've changed the code to use explicit intXX casts to avoid that.

It came about in the first place because the first time through `nimprof.hook()`, `t0` is uninitilized, which could  be out of range if QueryPerformanceCounter() returned a big enough int64.  Even with the timers fix, it's still possible to overflow the conversion to nanoseconds if you're unlucky, so I changed `nimprof.hook()` to initialize `t0` when it looks like it's the first time through.
