### PR TITLE
Fix unknown symbol in tables mpairs iterator.

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -104,7 +104,7 @@ iterator mpairs*[A, B](t: var Table[A, B]): tuple[key: A, val: var B] =
   ## iterates over any (key, value) pair in the table `t`. The values
   ## can be modified.
   for h in 0..high(t.data):
-    if isFilled(t.data[h].slot): yield (t.data[h].key, t.data[h].val)
+    if isFilled(t.data[h].hcode): yield (t.data[h].key, t.data[h].val)
 
 iterator keys*[A, B](t: Table[A, B]): A =
   ## iterates over any key in the table `t`.

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -109,6 +109,22 @@ block countTableTest1:
     else: break
     inc i
 
+block mpairsTableTest1:
+  var t = initTable[string, int]()
+  t["a"] = 1
+  t["b"] = 2
+  t["c"] = 3
+  t["d"] = 4
+  for k, v in t.mpairs:
+    if k == "a" or k == "c":
+      v = 9
+
+  for k, v in t.pairs:
+    if k == "a" or k == "c":
+      assert v == 9
+    else:
+      assert v != 1 and v != 3
+
 block SyntaxTest:
   var x = toTable[int, string]({:})
 


### PR DESCRIPTION
Fixes an error with mpairs iterator which was introduced with 5fbcf93860. This is used by nimforum thats why I found it. I also added a testcase for the mpairs iterator.