### PR TITLE
Add SSLFree after SLShutdown to prevent memory leak

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -454,6 +454,8 @@ proc close*(socket: Socket) =
         # shutdown i.e not wait for the peers "close notify" alert with a second
         # call to SSLShutdown
         let res = SSLShutdown(socket.sslHandle)
+        SSLFree(socket.sslHandle)
+        socket.sslHandle = nil
         if res == 0:
           discard
         elif res != 1:

--- a/lib/pure/sockets.nim
+++ b/lib/pure/sockets.nim
@@ -657,6 +657,8 @@ proc close*(socket: Socket) =
   when defined(ssl):
     if socket.isSSL:
       discard SSLShutdown(socket.sslHandle)
+      SSLFree(socket.sslHandle)
+      socket.sslHandle = nil
 
 proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
   ## Searches the database from the beginning and finds the first entry for 


### PR DESCRIPTION
Add SSLFree after SSLShutdown to prevent memory leak.