### PR TITLE
added support for double-dash delimiter

### DIFF
--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -108,20 +108,19 @@ proc next(p: var OptParser) =
     p.kind = cmdArgument
     p.key = token
     p.val = ""
-  elif token != "--":
-    if token.startsWith("--"):
-      p.kind = cmdLongOption
-      nextOption(p, token[2..token.len-1], allowEmpty=true)
-    elif token.startsWith("-"):
-      p.kind = cmdShortOption
-      nextOption(p, token[1..token.len-1], allowEmpty=true)
-    else:
-      p.kind = cmdArgument
-      p.key = token
-      p.val = ""
-  else:
+  elif token == "--":
     p.skipParser = true
     p.next()
+  elif token.startsWith("--"):
+    p.kind = cmdLongOption
+    nextOption(p, token[2..token.len-1], allowEmpty=true)
+  elif token.startsWith("-"):
+    p.kind = cmdShortOption
+    nextOption(p, token[1..token.len-1], allowEmpty=true)
+  else:
+    p.kind = cmdArgument
+    p.key = token
+    p.val = ""
 
 proc cmdLineRest*(p: OptParser): TaintedString {.rtl, extern: "npo$1", deprecated.} =
   ## Returns part of command line string that has not been parsed yet.


### PR DESCRIPTION
I would like to propose a change to parseopt2:

The POSIX "Utility Argument Syntax" recommends to accept the double-dash "--" argument as delimiter indicating the end of options. All following arguments should be treated as operands, even if they start with a "-" [see Guideline 10](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). Currently this cannot be handled using parseopt2, because the following arguments need to stay untouched. 

My patch implements this functionality. I am not sure, if my patch is the most elegant way to do this in nim, i have to admit, that these are my first few lines i am coding with nim ... but i stumbled over this problem,  because my attempt in learning nim is porting a command-line utility ...

