### PR TITLE
Make sure we can load root urls

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -391,7 +391,7 @@ proc request*(url: string, httpMethod: string, extraHeaders = "",
   var r = if proxy == nil: parseUri(url) else: proxy.url
   var headers = substr(httpMethod, len("http"))
   if proxy == nil:
-    headers.add(" " & r.path)
+    headers.add(" /" & r.path[1.. -1])
     if r.query.len > 0:
       headers.add("?" & r.query)
   else:


### PR DESCRIPTION
Without this, the getRequest procedure cannot load url roots - e.g. http://nim-lang.org

As urls with paths start always start with a leading /, we trim it off the string (as we unconditionally add it). This works even if path is empty.