### PR TITLE
streams.ssWriteData: Call setLen only when new data truly increases the underlying string buffer

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -224,10 +224,12 @@ proc ssReadData(s: Stream, buffer: pointer, bufLen: int): int =
 
 proc ssWriteData(s: Stream, buffer: pointer, bufLen: int) = 
   var s = StringStream(s)
-  if bufLen > 0: 
+  if bufLen <= 0:
+    return
+  if s.pos + bufLen > s.data.len():
     setLen(s.data, s.data.len + bufLen)
-    copyMem(addr(s.data[s.pos]), buffer, bufLen)
-    inc(s.pos, bufLen)
+  copyMem(addr(s.data[s.pos]), buffer, bufLen)
+  inc(s.pos, bufLen)
 
 proc ssClose(s: Stream) =
   var s = StringStream(s)

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -226,8 +226,8 @@ proc ssWriteData(s: Stream, buffer: pointer, bufLen: int) =
   var s = StringStream(s)
   if bufLen <= 0:
     return
-  if s.pos + bufLen > s.data.len():
-    setLen(s.data, s.data.len + bufLen)
+  if s.pos + bufLen > s.data.len:
+    setLen(s.data, s.pos + bufLen)
   copyMem(addr(s.data[s.pos]), buffer, bufLen)
   inc(s.pos, bufLen)
 


### PR DESCRIPTION
`s.pos` is where data will be written, So `s.pos+bufLen` should be used to determine whether the string buffer should be extended.

Normally this would not be a problem, but after `s.setPosition()` is invoded, the subsequent `s.Write` would result in a wrong `s.data.len`.

