### PR TITLE
Fix for readAll(stdin) problem on OS X and better anyway.

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -145,8 +145,8 @@ proc readAllFile(file: File): string =
 proc readAll(file: File): TaintedString = 
   # Separate handling needed because we need to buffer when we
   # don't know the overall length of the File.
-  var len = rawFileSize(file)
-  if len >= 0:
+  let len = if file != stdin: rawFileSize(file) else: -1
+  if len > 0:
     result = readAllFile(file, len).TaintedString
   else:
     result = readAllBuffer(file).TaintedString


### PR DESCRIPTION
Fix for https://github.com/Araq/Nim/issues/2228 - As I was bugged by that problem too I tried to find a way to make it work on mac. I got no good results with isatty() so I settled with comparing against the stdio file descriptor itself. Please anybody check this on Windows and Linux. (Note to myself: I need to get at least one of my Windows and Linux boxes in shape for Nim testing).