### PR TITLE
Fix #2247

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -572,6 +572,9 @@ proc footprint(filename: string): TCrc32 =
       getCompileCFileCmd(filename, true)
 
 proc externalFileChanged(filename: string): bool = 
+  if gCmd notin {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToLLVM}:
+    return false
+
   var crcFile = toGeneratedFile(filename.withPackageName, "crc")
   var currentCrc = int(footprint(filename))
   var f: File


### PR DESCRIPTION
If no actual compilation is going on, don't bother add the external files to
the compilation queue. This might be insufficient, there are tons more of
non-compiling modes for the compiler, including documentation generation and
who knows what else.

For that reason, /cc @Araq, so hopefully he can review this PR.