### PR TITLE
Only copy strings to their size, not capacity

### DIFF
--- a/lib/system/deepcopy.nim
+++ b/lib/system/deepcopy.nim
@@ -36,7 +36,7 @@ proc copyDeepString(src: NimString): NimString {.inline.} =
   if src != nil:
     result = rawNewStringNoInit(src.len)
     result.len = src.len
-    c_memcpy(result.data, src.data, (src.len + 1) * sizeof(char))
+    c_memcpy(result.data, src.data, src.len + 1)
 
 proc genericDeepCopyAux(dest, src: pointer, mt: PNimType) =
   var

--- a/lib/system/deepcopy.nim
+++ b/lib/system/deepcopy.nim
@@ -34,7 +34,7 @@ proc genericDeepCopyAux(dest, src: pointer, n: ptr TNimNode) {.benign.} =
 
 proc copyDeepString(src: NimString): NimString {.inline.} =
   if src != nil:
-    result = rawNewString(src.space)
+    result = rawNewStringNoInit(src.len)
     result.len = src.len
     c_memcpy(result.data, src.data, (src.len + 1) * sizeof(char))
 

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -117,7 +117,7 @@ proc usrToCell(usr: pointer): PCell {.inline.} =
   # convert pointer to userdata to object (=pointer to refcount)
   result = cast[PCell](cast[ByteAddress](usr)-%ByteAddress(sizeof(TCell)))
 
-proc canbeCycleRoot(c: PCell): bool {.inline.} =
+proc canBeCycleRoot(c: PCell): bool {.inline.} =
   result = ntfAcyclic notin c.typ.flags
 
 proc extGetCellType(c: pointer): PNimType {.compilerproc.} =

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -593,7 +593,7 @@ proc addNewObjToZCT(res: PCell, gch: var TGcHeap) {.inline.} =
         return
     add(gch.zct, res)
 
-proc rawNewObj(typ: PNimType, size: int, gch: var TGcHeap, rc1: bool): pointer =
+proc rawNewObj(typ: PNimType, size: int, gch: var TGcHeap, rc1 = false): pointer =
   # generates a new object and sets its reference counter to 0
   acquire(gch)
   sysAssert(allocInv(gch.region), "rawNewObj begin")

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -77,13 +77,13 @@ proc copyString(src: NimString): NimString {.compilerRtl.} =
     if (src.reserved and seqShallowFlag) != 0:
       result = src
     else:
-      result = rawNewString(src.space)
+      result = rawNewString(src.len)
       result.len = src.len
       c_memcpy(result.data, src.data, (src.len + 1) * sizeof(char))
 
 proc copyStringRC1(src: NimString): NimString {.compilerRtl.} =
   if src != nil:
-    var s = src.space
+    var s = src.len
     if s < 8: s = 7
     when declared(newObjRC1):
       result = cast[NimString](newObjRC1(addr(strDesc), sizeof(TGenericSeq) +

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -67,7 +67,8 @@ proc copyStrLast(s: NimString, start, last: int): NimString {.compilerProc.} =
   if len > 0:
     result = rawNewStringNoInit(len)
     result.len = len
-    c_memcpy(result.data, addr(s.data[start]), len + 1)
+    c_memcpy(result.data, addr(s.data[start]), len)
+    result.data[len] = '\0'
   else:
     result = rawNewString(len)
 


### PR DESCRIPTION
Capacity may be much bigger, so we end up with strings that are much
larger than they have to be and have to copy more as well.