### PR TITLE
Add SNI support to client and server sockets.

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -95,7 +95,7 @@ type
       address_v4*: array[0..3, uint8] ## Contains the IP address in bytes in
                                       ## case of IPv4
 
-proc isIpAddress*(address_str: string): bool
+proc isIpAddress*(address_str: string): bool {.tags: [].}
 proc parseIpAddress*(address_str: string): TIpAddress
 
 proc isDisconnectionError*(flags: set[SocketFlag],
@@ -504,7 +504,7 @@ proc setSockOpt*(socket: Socket, opt: SOBool, value: bool, level = SOL_SOCKET) {
   setSockOptInt(socket.fd, cint(level), toCInt(opt), valuei)
 
 proc connect*(socket: Socket, address: string, port = Port(0), 
-              af: Domain = AF_INET) {.tags: [ReadIOEffect, RootEffect].} =
+              af: Domain = AF_INET) {.tags: [ReadIOEffect].} =
   ## Connects socket to ``address``:``port``. ``Address`` can be an IP address or a
   ## host name. If ``address`` is a host name, this function will try each IP
   ## of that host name. ``htons`` is already performed on ``port`` so you must

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1250,7 +1250,7 @@ proc parseIPv6Address(address_str: string): TIpAddress =
     raise newException(ValueError,
       "Invalid IP Address. The address consists of too many groups")
 
-proc parseIpAddress*(address_str: string): TIpAddress =
+proc parseIpAddress(address_str: string): TIpAddress =
   ## Parses an IP address
   ## Raises EInvalidValue on error
   if address_str == nil:
@@ -1261,7 +1261,7 @@ proc parseIpAddress*(address_str: string): TIpAddress =
     return parseIPv4Address(address_str)
 
 
-proc isIpAddress*(address_str: string): bool =
+proc isIpAddress(address_str: string): bool =
   ## Checks if a string is an IP address
   ## Returns true if it is, false otherwise
   try:

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -141,6 +141,14 @@ const
   SSL_CTRL_GET_MAX_CERT_LIST* = 50
   SSL_CTRL_SET_MAX_CERT_LIST* = 51 #* Allow SSL_write(..., n) to return r with 0 < r < n (i.e. report success
                                    # * when just a single record has been written): *
+  SSL_CTRL_SET_TLSEXT_SERVERNAME_CB = 53
+  SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG = 54
+  SSL_CTRL_SET_TLSEXT_HOSTNAME = 55
+  TLSEXT_NAMETYPE_host_name* = 0
+  SSL_TLSEXT_ERR_OK* = 0
+  SSL_TLSEXT_ERR_ALERT_WARNING* = 1
+  SSL_TLSEXT_ERR_ALERT_FATAL* = 2
+  SSL_TLSEXT_ERR_NOACK* = 3
   SSL_MODE_ENABLE_PARTIAL_WRITE* = 1 #* Make it possible to retry SSL_write() with changed buffer location
                                      # * (buffer contents must stay the same!); this is not the default to avoid
                                      # * the misconception that non-blocking SSL_write() behaves like
@@ -296,8 +304,26 @@ proc CRYPTO_malloc_init*() =
 proc SSL_CTX_ctrl*(ctx: SslCtx, cmd: cInt, larg: int, parg: pointer): int{.
   cdecl, dynlib: DLLSSLName, importc.}
 
+proc SSL_CTX_callback_ctrl(ctx: SslCtx, typ: cInt, fp: PFunction): int{.
+  cdecl, dynlib: DLLSSLName, importc.}
+
 proc SSLCTXSetMode*(ctx: SslCtx, mode: int): int =
   result = SSL_CTX_ctrl(ctx, SSL_CTRL_MODE, mode, nil)
+
+proc SSL_ctrl*(ssl: SslPtr, cmd: cInt, larg: int, parg: pointer): int{.
+  cdecl, dynlib: DLLSSLName, importc.}
+
+proc SSL_set_tlsext_host_name*(ssl: SslPtr, name: cstring): int =
+  result = SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, name)
+
+proc SSL_get_servername*(ssl: SslPtr, typ: cInt = TLSEXT_NAMETYPE_host_name): cstring {.cdecl, dynlib: DLLSSLName, importc.}
+
+proc SSL_CTX_set_tlsext_servername_callback*(ctx: SslCtx, cb: PFunction): int =
+  result = SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cb)
+
+proc SSL_CTX_set_tlsext_servername_arg*(ctx: SslCtx, arg: pointer): int =
+  result = SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, arg)
+
 
 proc bioNew*(b: PBIO_METHOD): BIO{.cdecl, dynlib: DLLUtilName, importc: "BIO_new".}
 proc bioFreeAll*(b: BIO){.cdecl, dynlib: DLLUtilName, importc: "BIO_free_all".}
@@ -341,8 +367,6 @@ else:
       dynlib: DLLSSLName, importc.}
 
   proc SslSetFd*(s: PSSL, fd: cInt): cInt{.cdecl, dynlib: DLLSSLName, importc.}
-  proc SslCtrl*(ssl: PSSL, cmd: cInt, larg: int, parg: Pointer): int{.cdecl, 
-      dynlib: DLLSSLName, importc.}
   proc SslCTXCtrl*(ctx: PSSL_CTX, cmd: cInt, larg: int, parg: Pointer): int{.
       cdecl, dynlib: DLLSSLName, importc.}
 

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -50,7 +50,7 @@ when useWinVersion:
   from winlean import SocketHandle
 else:
   const
-    versions = "(.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.0.9.7|.0.9.6|.0.9.5|.0.9.4)"
+    versions = "(.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8)"
   when defined(macosx):
     const
       DLLSSLName = "libssl" & versions & ".dylib"

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -319,9 +319,12 @@ proc SSL_set_tlsext_host_name*(ssl: SslPtr, name: cstring): int =
 proc SSL_get_servername*(ssl: SslPtr, typ: cInt = TLSEXT_NAMETYPE_host_name): cstring {.cdecl, dynlib: DLLSSLName, importc.}
 
 proc SSL_CTX_set_tlsext_servername_callback*(ctx: SslCtx, cb: PFunction): int =
+  ## Set the callback to be used on listening SSL connections when the client hello is received.
+  ## Callback proc ``cb`` should be of the form `proc (ssl: SslPtr, cb_id: int, arg: pointer): int`
   result = SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cb)
 
 proc SSL_CTX_set_tlsext_servername_arg*(ctx: SslCtx, arg: pointer): int =
+  ## Set the pointer to be used in the callback registered to ``SSL_CTX_set_tlsext_servername_callback``.
   result = SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, arg)
 
 

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -315,12 +315,24 @@ proc SSL_ctrl*(ssl: SslPtr, cmd: cInt, larg: int, parg: pointer): int{.
 
 proc SSL_set_tlsext_host_name*(ssl: SslPtr, name: cstring): int =
   result = SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, name)
+  ## Set the SNI server name extension to be used in a client hello.
+  ## Returns 1 if SNI was set, 0 if current SSL configuration doesn't support SNI.
+
 
 proc SSL_get_servername*(ssl: SslPtr, typ: cInt = TLSEXT_NAMETYPE_host_name): cstring {.cdecl, dynlib: DLLSSLName, importc.}
+  ## Retrieve the server name requested in the client hello. This can be used
+  ## in the callback set in `SSL_CTX_set_tlsext_servername_callback` to
+  ## implement virtual hosting. May return `nil`.
 
 proc SSL_CTX_set_tlsext_servername_callback*(ctx: SslCtx, cb: PFunction): int =
   ## Set the callback to be used on listening SSL connections when the client hello is received.
   ## Callback proc ``cb`` should be of the form `proc (ssl: SslPtr, cb_id: int, arg: pointer): int`
+  ##
+  ## The callback should return one of:
+  ## * SSL_TLSEXT_ERR_OK
+  ## * SSL_TLSEXT_ERR_ALERT_WARNING
+  ## * SSL_TLSEXT_ERR_ALERT_FATAL
+  ## * SSL_TLSEXT_ERR_NOACK
   result = SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cb)
 
 proc SSL_CTX_set_tlsext_servername_arg*(ctx: SslCtx, arg: pointer): int =

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -324,16 +324,15 @@ proc SSL_get_servername*(ssl: SslPtr, typ: cInt = TLSEXT_NAMETYPE_host_name): cs
   ## in the callback set in `SSL_CTX_set_tlsext_servername_callback` to
   ## implement virtual hosting. May return `nil`.
 
-proc SSL_CTX_set_tlsext_servername_callback*(ctx: SslCtx, cb: PFunction): int =
+proc SSL_CTX_set_tlsext_servername_callback*(ctx: SslCtx, cb: proc(ssl: SslPtr, cb_id: int, arg: pointer): int {.cdecl.}): int =
   ## Set the callback to be used on listening SSL connections when the client hello is received.
-  ## Callback proc ``cb`` should be of the form `proc (ssl: SslPtr, cb_id: int, arg: pointer): int`
   ##
   ## The callback should return one of:
   ## * SSL_TLSEXT_ERR_OK
   ## * SSL_TLSEXT_ERR_ALERT_WARNING
   ## * SSL_TLSEXT_ERR_ALERT_FATAL
   ## * SSL_TLSEXT_ERR_NOACK
-  result = SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cb)
+  result = SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast[PFunction](cb))
 
 proc SSL_CTX_set_tlsext_servername_arg*(ctx: SslCtx, arg: pointer): int =
   ## Set the pointer to be used in the callback registered to ``SSL_CTX_set_tlsext_servername_callback``.

--- a/tests/stdlib/tnet.nim
+++ b/tests/stdlib/tnet.nim
@@ -1,0 +1,47 @@
+import net
+import unittest
+
+suite "isIpAddress tests":
+  test "127.0.0.1 is valid":
+    check isIpAddress("127.0.0.1") == true
+
+  test "ipv6 localhost is valid":
+    check isIpAddress("::1") == true
+
+  test "fqdn is not an ip address":
+    check isIpAddress("example.com") == false
+
+  test "random string is not an ipaddress":
+    check isIpAddress("foo bar") == false
+
+  test "5127.0.0.1 is invalid":
+    check isIpAddress("5127.0.0.1") == false
+
+  test "ipv6 is valid":
+    check isIpAddress("2001:cdba:0000:0000:0000:0000:3257:9652") == true
+
+  test "invalid ipv6":
+    check isIpAddress("gggg:cdba:0000:0000:0000:0000:3257:9652") == false
+
+
+suite "parseIpAddress tests":
+  test "127.0.0.1 is valid":
+    discard parseIpAddress("127.0.0.1")
+
+  test "ipv6 localhost is valid":
+    discard parseIpAddress("::1")
+
+  test "fqdn is not an ip address":
+    expect(ValueError):
+      discard parseIpAddress("example.com")
+
+  test "random string is not an ipaddress":
+    expect(ValueError):
+      discard parseIpAddress("foo bar")
+
+  test "ipv6 is valid":
+    discard parseIpAddress("2001:cdba:0000:0000:0000:0000:3257:9652")
+
+  test "invalid ipv6":
+    expect(ValueError):
+      discard parseIpAddress("gggg:cdba:0000:0000:0000:0000:3257:9652")


### PR DESCRIPTION
So to be clear, I don't consider this complete just yet, but I'm looking for some feedback as I'm very new to Nim. This is in fact the first code I've written, so I have a few noobish questions...

- Are there forward declarations for types? I had to move the definition of `TIpAddress` to before `connect`, so that I could use it.
- `RootEffect`, is this a "base" effect? I couldn't compile the code without adding it to the `connect` method definition, and it feels kind of bad.
- The interface on the callback functions is quite poor to use and involves casts, some to deal with net.SslContext being a distinct SslCtx. Is there a way to make this any nicer to use? (See below example)
- I've got a pretty loose set of integers that should be used for the return codes of the servername callback function. I think an enum would be nice, but I don't know how to enforce it and then mutate it back into an integer for OpenSSL.
- I haven't updated the ssl or sockets modules, as they are deprecated.

In general, how does this code seem, style and idiom wise? Happy to take any criticisms/change anything to get it accepted. Once the above issues have been resolved, I'll resubmit with documentation.

```
import net
import openssl

var s = newSocket()
var ctx = newContext(protVersion=protTLSv1, certFile="cert.pem", keyFile="key.pem")
ctx.wrapSocket(s)

s.bindAddr(Port(8081), "127.0.0.1")

var b = true

proc myfunc(ssl: SslPtr, cb_id: int, arg: pointer): int =
    var g = SSL_get_servername(ssl)
    if not isNil(g):
        echo "server name is ", g

    var c = cast[ptr bool](arg)

    echo "modifying arg value ", c[], " ", b
    c[] = false
    echo "modifed arg value? ", c[], " ", b

    return SSL_TLSEXT_ERR_NOACK

# FIXME: can these casts to SslCtx be avoided?
echo "setting callback", SSL_CTX_set_tlsext_servername_callback(cast[SslCtx](ctx), cast[PFunction](myfunc))
echo "setting callback ", SSL_CTX_set_tlsext_servername_arg(cast[SslCtx](ctx), addr(b))

while true:
    s.listen()

    var c = newSocket()
    s.accept(c)

    echo "accepted client"
```