### PR TITLE
fixed a bug in nimble tests - disable for now

### DIFF
--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -302,8 +302,7 @@ proc testNimblePackages(r: var TResults, cat: Category, filter: PackageFilter) =
         continue
 
       let
-        buildPath = getPackageDir(name)[0.. -3]
-      let
+        buildPath = getPackageDir(name).strip
         buildProcess = startProcess(nimbleExe, buildPath, ["build"])
         buildStatus = waitForExitEx(buildProcess)
       buildProcess.close
@@ -318,7 +317,7 @@ proc testNimblePackages(r: var TResults, cat: Category, filter: PackageFilter) =
 
 # ----------------------------------------------------------------------------
 
-const AdditionalCategories = ["debugger", "examples", "lib", "nimble-core"]
+const AdditionalCategories = ["debugger", "examples", "lib"]
 
 proc `&.?`(a, b: string): string =
   # candidate for the stdlib?


### PR DESCRIPTION
I think the original intent was to remove the newline. Also, disable nimble tests for now, they seem to hang.