### PR TITLE
Rewrite `x[<-]` to `x[x.low]` and `x[->]` to `x[x.high]`

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -410,8 +410,8 @@ proc qualifiedIdent(p: var TParser): PNode =
 proc genSelfDotExpr(p: var TParser, snd: string, result: PNode) =
     let a = newNodeP(nkDotExpr, p)
     addSon(result, a)
-    let b = newIdentNodeP(result.sons[0].ident, p)
-    addSon(a, b)
+    var s = result.sons[0]
+    addSon(a, result.sons[0]) # is that legal?
     let c = newIdentNodeP(getIdent(snd), p)
     addSon(a, c)
     getTok(p)


### PR DESCRIPTION
I saw that question about easier first / last element access in the feature requests and thought I give it a shot. How do you like it?

Example:
```nimrod
let x = [0,1,2,3,4,5,6,7,8,9]

echo x[<-] # 0
echo x[->] # 9
```