### PR TITLE
Fixing import path support inconsitency.

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -27,7 +27,7 @@ proc getModuleName*(n: PNode): string =
     result = n.ident.s
   of nkSym:
     result = n.sym.name.s
-  of nkInfix:
+  of nkInfix, nkPrefix:
     if n.sons[0].kind == nkIdent and n.sons[0].ident.id == getIdent("as").id:
       # XXX hack ahead:
       n.kind = nkImportAs


### PR DESCRIPTION
I believe this is a fix for issue #2281

```nim
import ../usefull/coolmodule
import ../masterlib
```
both work now. Without the fix the second import fails with "../ masterlib" can't be found.