### PR TITLE
Fixes tzname on osx (and presumable bsd).

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -48,6 +48,11 @@ when defined(posix) and not defined(JS):
   proc posix_gettimeofday(tp: var Timeval, unused: pointer = nil) {.
     importc: "gettimeofday", header: "<sys/time.h>".}
 
+  # we also need tzset() to make sure that tzname is initialized
+  proc tzset() {.importc, header: "<sys/time.h>".}
+  # calling tzset() implicitly to initialize tzname data.
+  tzset()
+
 elif defined(windows):
   import winlean
   


### PR DESCRIPTION
Fix for https://github.com/Araq/Nim/issues/2301. I think it is OK to do this on all systems even if it works without on linux for me. 
I found that "documented" here: http://www.win.tue.nl/~aeb/ftpdocs/linux-local/libc.archive/libc/libc-4.4.1/jumptable1/time/time_data.c
It will also work if "localtime()" was called before. So it may get initialized "by chance" before.