### PR TITLE
openssl: do not set mem functions on osx

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -298,7 +298,7 @@ when not useWinVersion:
     if p != nil: dealloc(p)
 
 proc CRYPTO_malloc_init*() =
-  when not useWinVersion:
+  when not useWinVersion and not defined(macosx):
     CRYPTO_set_mem_functions(allocWrapper, reallocWrapper, deallocWrapper)
 
 proc SSL_CTX_ctrl*(ctx: SslCtx, cmd: cInt, larg: int, parg: pointer): int{.


### PR DESCRIPTION
As discussed in the [forum](http://forum.nim-lang.org/t/969) this leads to strange SIGSEGV errors on Mac OS X. As i did not discover any such issues when compiling on Linux, i thought it might be better to just add Mac OS X to the excluded platforms to fix this.