### PR TITLE
Make readFile work with FIFO files

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -154,7 +154,7 @@ proc readAll(file: File): TaintedString =
 proc readFile(filename: string): TaintedString =
   var f = open(filename)
   try:
-    result = readAllFile(f).TaintedString
+    result = readAll(f).TaintedString
   finally:
     close(f)
 


### PR DESCRIPTION
For a minimal example:
```
$ mkfifo foo.fifo
$ cat foo.nim
echo readFile "foo.fifo"
$ nim -r c foo.nim
$ echo "Hello World" > foo.fifo
```

This used to crash, now it works. Fifos have file size `-1`, just as stdin, so they have to be handled the same way.