### PR TITLE
Improve error message for failed conversion in VM

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -814,7 +814,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
               leValueConv(regs[ra].regToNode, regs[rc].regToNode)):
         stackTrace(c, tos, pc, errGenerated,
           msgKindToString(errIllegalConvFromXtoY) % [
-          "unknown type" , "unknown type"])
+          $regs[ra].regToNode, "[" & $regs[rb].regToNode & ".." & $regs[rc].regToNode & "]"])
     of opcIndCall, opcIndCallAsgn:
       # dest = call regStart, n; where regStart = fn, arg1, ...
       let rb = instr.regB


### PR DESCRIPTION
- Fixes #2045

- Old one: Error: conversion from unknown type to unknown type is invalid
- New one: Error: conversion from -1 to [0..255] is invalid