### PR TITLE
fixed writeln line on log*( logger: RollingFileLogger)

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -217,7 +217,7 @@ method log*(logger: RollingFileLogger, level: Level,
       logger.curLine = 0
       logger.f = open(logger.baseName, logger.baseMode)
     
-    writeln(logger.f, LevelNames[level], " ", frmt % args)
+    writeln(logger.f, LevelNames[level], " ",substituteLog(logger.fmtStr), frmt % args)
     logger.curLine.inc
 
 # --------


### PR DESCRIPTION
writeln line on log proc for RollingFileLogger left out the substituteLog(logger.fmtStr) parameter