### PR TITLE
Add character set options when opening DB connection, default to UTF-8

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -212,8 +212,8 @@ proc close*(db: TDbConn) {.tags: [FDb].} =
   ## closes the database connection.
   if db != nil: mysql.close(db)
 
-proc open*(connection, user, password, database: string): TDbConn {.
-  tags: [FDb].} =
+proc open*(connection, user, password, database: string, 
+           charset: string = "utf8"): TDbConn {.tags: [FDb].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established.
   result = mysql.init(nil)
@@ -226,6 +226,10 @@ proc open*(connection, user, password, database: string): TDbConn {.
                   else: substr(connection, colonPos+1).parseInt.int32
   if mysql.realConnect(result, host, user, password, database, 
                        port, nil, 0) == nil:
+    var errmsg = $mysql.error(result)
+    db_mysql.close(result)
+    dbError(errmsg)
+  if mysql.set_character_set(result, charset) == 0:
     var errmsg = $mysql.error(result)
     db_mysql.close(result)
     dbError(errmsg)

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -212,8 +212,8 @@ proc close*(db: TDbConn) {.tags: [FDb].} =
   ## closes the database connection.
   if db != nil: mysql.close(db)
 
-proc open*(connection, user, password, database: string, 
-           charset: string = "utf8"): TDbConn {.tags: [FDb].} =
+proc open*(connection, user, password, database: string): TDbConn {.
+  tags: [FDb].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established.
   result = mysql.init(nil)
@@ -229,7 +229,9 @@ proc open*(connection, user, password, database: string,
     var errmsg = $mysql.error(result)
     db_mysql.close(result)
     dbError(errmsg)
-  if mysql.set_character_set(result, charset) == 0:
-    var errmsg = $mysql.error(result)
-    db_mysql.close(result)
-    dbError(errmsg)
+
+proc setEncoding*(connection: TDbConn, encoding: string): bool {.
+  tags: [FDb].} =
+  ## sets the encoding of a database connection, returns true for 
+  ## success, false for failure.
+  result = mysql.set_character_set(connection, encoding) == 0

--- a/lib/impure/db_postgres.nim
+++ b/lib/impure/db_postgres.nim
@@ -239,8 +239,8 @@ proc close*(db: TDbConn) {.tags: [FDb].} =
   ## closes the database connection.
   if db != nil: pqfinish(db)
 
-proc open*(connection, user, password, database: string): TDbConn {.
-  tags: [FDb].} =
+proc open*(connection, user, password, database: string, 
+           charset: string = "UTF-8"): TDbConn {.tags: [FDb].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established.
   ##
@@ -260,3 +260,4 @@ proc open*(connection, user, password, database: string): TDbConn {.
   ## the nim db api.
   result = pqsetdbLogin(nil, nil, nil, nil, database, user, password)
   if pqStatus(result) != CONNECTION_OK: dbError(result) # result = nil
+  if pqsetClientEncoding(result, charset) != 0: dbError(result)

--- a/lib/impure/db_postgres.nim
+++ b/lib/impure/db_postgres.nim
@@ -239,8 +239,8 @@ proc close*(db: TDbConn) {.tags: [FDb].} =
   ## closes the database connection.
   if db != nil: pqfinish(db)
 
-proc open*(connection, user, password, database: string, 
-           charset: string = "UTF-8"): TDbConn {.tags: [FDb].} =
+proc open*(connection, user, password, database: string): TDbConn {.
+  tags: [FDb].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established.
   ##
@@ -260,4 +260,9 @@ proc open*(connection, user, password, database: string,
   ## the nim db api.
   result = pqsetdbLogin(nil, nil, nil, nil, database, user, password)
   if pqStatus(result) != CONNECTION_OK: dbError(result) # result = nil
-  if pqsetClientEncoding(result, charset) != 0: dbError(result)
+
+proc setEncoding*(connection: TDbConn, encoding: string): bool {.
+  tags: [FDb].} =
+  ## sets the encoding of a database connection, returns true for 
+  ## success, false for failure.
+  return pqsetClientEncoding(connection, encoding) == 0

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -183,13 +183,14 @@ proc close*(db: TDbConn) {.tags: [FDb].} =
   ## closes the database connection.
   if sqlite3.close(db) != SQLITE_OK: dbError(db)
     
-proc open*(connection, user, password, database: string): TDbConn {.
-  tags: [FDb].} =
+proc open*(connection, user, password, database: string, 
+           charset: string = "UTF-8"): TDbConn {.tags: [FDb].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established. Only the ``connection`` parameter is used for ``sqlite``.
   var db: TDbConn
   if sqlite3.open(connection, db) == SQLITE_OK:
     result = db
+    exec(result, sql"PRAGMA encoding = ?", [charset])
   else:
     dbError(db)
    


### PR DESCRIPTION
Resolving #2261
The default value for MySQL is different from the others since they seem to use different names for UTF-8.
It's been tested for MySQL and SQLite3.
For PostgreSQL it's written according to the [documentation](http://www.postgresql.org/docs/8.3/static/libpq-control.html#AEN32490) but not tested since I don't have it on my machine.