### PR TITLE
Expands tildes for entries in $PATH when looking for a binary.

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1863,16 +1863,18 @@ proc getFileSize*(file: string): BiggestInt {.rtl, extern: "nos$1",
       close(f)
     else: raiseOSError(osLastError())
 
+proc expandTilde*(path: string): string {.tags: [ReadEnvEffect].}
+
 proc findExe*(exe: string): string {.tags: [ReadDirEffect, ReadEnvEffect].} =
   ## Searches for `exe` in the current working directory and then
   ## in directories listed in the ``PATH`` environment variable.
   ## Returns "" if the `exe` cannot be found. On DOS-like platforms, `exe`
-  ## is added an ``.exe`` file extension if it has no extension.
+  ## is added the `ExeExt <#ExeExt>`_ file extension if it has none.
   result = addFileExt(exe, os.ExeExt)
   if existsFile(result): return
   var path = string(os.getEnv("PATH"))
   for candidate in split(path, PathSep):
-    var x = candidate / result
+    var x = expandTilde(candidate) / result
     if existsFile(x): return x
   result = ""
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1874,7 +1874,10 @@ proc findExe*(exe: string): string {.tags: [ReadDirEffect, ReadEnvEffect].} =
   if existsFile(result): return
   var path = string(os.getEnv("PATH"))
   for candidate in split(path, PathSep):
-    var x = expandTilde(candidate) / result
+    when defined(windows):
+      var x = candidate / result
+    else:
+      var x = expandTilde(candidate) / result
     if existsFile(x): return x
   result = ""
 


### PR DESCRIPTION
Installing nimble on a fresh machine I was greeted with an odd error:
```
Traceback (most recent call last)
nimble.nim(871)          nimble
nimble.nim(134)          parseCmdLine
config.nim(22)           parseConfig
config.nim(14)           initConfig
tools.nim(44)            getNimrodVersion
tools.nim(26)            doCmdEx
Error: unhandled exception: 'nim' not in PATH. [NimbleError]
Error: execution of an external program failed
```
The machine's ``$PATH`` contained a path with a tilde, so ``findExe`` wasn't able to find it despite that compiler instance being used to compile and run nimble itself.