### PR TITLE
Fix addr calls

### DIFF
--- a/examples/sdlex.nim
+++ b/examples/sdlex.nim
@@ -30,19 +30,19 @@ r.y = 0
 
 block game_loop:
   while true:
-    
-    while pollEvent(addr event) > 0:
+
+    while pollEvent(addr(event)) > 0:
       case event.kind
       of QUITEV:
         break game_loop
       of KEYDOWN:
-        if evKeyboard(addr event).keysym.sym == K_ESCAPE:
+        if evKeyboard(addr(event)).keysym.sym == K_ESCAPE:
           break game_loop
       else:
         discard
-    
-    discard fillRect(screen, nil, bgColor) 
-    discard blitSurface(greeting, nil, screen, addr r)
+
+    discard fillRect(screen, nil, bgColor)
+    discard blitSurface(greeting, nil, screen, addr(r))
     discard flip(screen)
 
 greeting.freeSurface()

--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -24,7 +24,7 @@
 ##
 ## Chat server
 ## ^^^^^^^^^^^
-## 
+##
 ## The following example demonstrates a simple chat server.
 ##
 ## .. code-block::nim
@@ -137,7 +137,7 @@ when defined(ssl):
     let len = bioCtrlPending(socket.bioOut)
     if len > 0:
       var data = newStringOfCap(len)
-      let read = bioRead(socket.bioOut, addr data[0], len)
+      let read = bioRead(socket.bioOut, addr(data[0]), len)
       assert read != 0
       if read < 0:
         raiseSslError()
@@ -151,7 +151,7 @@ when defined(ssl):
       await sendPendingSslData(socket, flags)
     of SSL_ERROR_WANT_READ:
       var data = await recv(socket.fd.TAsyncFD, BufferSize, flags)
-      let ret = bioWrite(socket.bioIn, addr data[0], data.len.cint)
+      let ret = bioWrite(socket.bioIn, addr(data[0]), data.len.cint)
       if ret < 0:
         raiseSSLError()
     else:
@@ -193,13 +193,13 @@ proc readInto(buf: cstring, size: int, socket: AsyncSocket,
   else:
     var data = await recv(socket.fd.TAsyncFD, size, flags)
     if data.len != 0:
-      copyMem(buf, addr data[0], data.len)
+      copyMem(buf, addr(data[0]), data.len)
     # Not in SSL mode.
     result = data.len
 
 proc readIntoBuf(socket: AsyncSocket,
     flags: set[SocketFlag]): Future[int] {.async.} =
-  result = await readInto(addr socket.buffer[0], BufferSize, socket, flags)
+  result = await readInto(addr(socket.buffer[0]), BufferSize, socket, flags)
   socket.currPos = 0
   socket.bufLen = result
 
@@ -251,7 +251,7 @@ proc recv*(socket: AsyncSocket, size: int,
     result.setLen(read)
   else:
     result = newString(size)
-    let read = await readInto(addr result[0], size, socket, flags)
+    let read = await readInto(addr(result[0]), size, socket, flags)
     result.setLen(read)
 
 proc send*(socket: AsyncSocket, data: string,
@@ -263,7 +263,7 @@ proc send*(socket: AsyncSocket, data: string,
     when defined(ssl):
       var copy = data
       sslLoop(socket, flags,
-        sslWrite(socket.sslHandle, addr copy[0], copy.len.cint))
+        sslWrite(socket.sslHandle, addr(copy[0]), copy.len.cint))
       await sendPendingSslData(socket, flags)
   else:
     await send(socket.fd.TAsyncFD, data, flags)
@@ -310,7 +310,7 @@ proc recvLine*(socket: AsyncSocket,
   ## If a full line is read ``\r\L`` is not
   ## added to ``line``, however if solely ``\r\L`` is read then ``line``
   ## will be set to it.
-  ## 
+  ##
   ## If the socket is disconnected, ``line`` will be set to ``""``.
   ##
   ## If the socket is disconnected in the middle of a line (before ``\r\L``
@@ -318,7 +318,7 @@ proc recvLine*(socket: AsyncSocket,
   ## The partial line **will be lost**.
   ##
   ## **Warning**: The ``Peek`` flag is not yet implemented.
-  ## 
+  ##
   ## **Warning**: ``recvLine`` on unbuffered sockets assumes that the protocol
   ## uses ``\r\L`` to delimit a new line.
   template addNLIfEmpty(): stmt =
@@ -500,11 +500,11 @@ when isMainModule:
         proc (future: Future[void]) =
           echo("Send")
           client.close()
-      
+
       var f = accept(sock)
       f.callback = onAccept
-      
+
     var f = accept(sock)
     f.callback = onAccept
   runForever()
-    
+

--- a/lib/pure/concurrency/cpuload.nim
+++ b/lib/pure/concurrency/cpuload.nim
@@ -34,7 +34,7 @@ proc advice*(s: var ThreadPoolState): ThreadPoolAdvice =
       sysIdle, sysKernel, sysUser,
         procCreation, procExit, procKernel, procUser: TFILETIME
     if getSystemTimes(sysIdle, sysKernel, sysUser) == 0 or
-        getProcessTimes(THandle(-1), procCreation, procExit, 
+        getProcessTimes(THandle(-1), procCreation, procExit,
                         procKernel, procUser) == 0:
       return doNothing
     if s.calls > 0:
@@ -57,14 +57,14 @@ proc advice*(s: var ThreadPoolState): ThreadPoolAdvice =
     s.prevProcKernel = procKernel
     s.prevProcUser = procUser
   elif defined(linux):
-    proc fscanf(c: File, frmt: cstring) {.varargs, importc, 
+    proc fscanf(c: File, frmt: cstring) {.varargs, importc,
       header: "<stdio.h>".}
 
     var f = open("/proc/loadavg")
     var b: float
     var busy, total: int
     fscanf(f,"%lf %lf %lf %ld/%ld",
-           addr b, addr b, addr b, addr busy, addr total)
+           addr(b), addr(b), addr(b), addr(busy), addr(total))
     f.close()
     let cpus = countProcessors()
     if busy-1 < cpus:

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -8,7 +8,7 @@
 #
 
 ## Nim OID support. An OID is a global ID that consists of a timestamp,
-## a unique counter and a random value. This combination should suffice to 
+## a unique counter and a random value. This combination should suffice to
 ## produce a globally distributed unique ID. This implementation was extracted
 ## from the Mongodb interface and it thus binary compatible with a Mongo OID.
 ##
@@ -19,13 +19,13 @@ import times, endians
 
 type
   Oid* = object ## an OID
-    time: int32  ## 
-    fuzz: int32  ## 
-    count: int32 ## 
+    time: int32  ##
+    fuzz: int32  ##
+    count: int32 ##
 
 {.deprecated: [Toid: Oid].}
 
-proc hexbyte*(hex: char): int = 
+proc hexbyte*(hex: char): int =
   case hex
   of '0'..'9': result = (ord(hex) - ord('0'))
   of 'a'..'f': result = (ord(hex) - ord('a') + 10)
@@ -40,7 +40,7 @@ proc parseOid*(str: cstring): Oid =
     bytes[i] = chr((hexbyte(str[2 * i]) shl 4) or hexbyte(str[2 * i + 1]))
     inc(i)
 
-proc oidToString*(oid: Oid, str: cstring) = 
+proc oidToString*(oid: Oid, str: cstring) =
   const hex = "0123456789abcdef"
   # work around a compiler bug:
   var str = str
@@ -59,7 +59,7 @@ proc `$`*(oid: Oid): string =
   oidToString(oid, result)
 
 var
-  incr: int 
+  incr: int
   fuzz: int32
 
 proc genOid*(): Oid =
@@ -69,17 +69,17 @@ proc genOid*(): Oid =
   proc srand(seed: cint) {.importc: "srand", header: "<stdlib.h>", nodecl.}
 
   var t = gettime(nil)
-  
+
   var i = int32(incr)
   atomicInc(incr)
-  
+
   if fuzz == 0:
     # racy, but fine semantically:
     srand(t)
     fuzz = rand()
-  bigEndian32(addr result.time, addr(t))
+  bigEndian32(addr(result.time), addr(t))
   result.fuzz = fuzz
-  bigEndian32(addr result.count, addr(i))
+  bigEndian32(addr(result.count), addr(i))
 
 proc generatedTime*(oid: Oid): Time =
   ## returns the generated timestamp of the OID.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -41,7 +41,7 @@ type
 
   OSErrorCode* = distinct int32 ## Specifies an OS Error Code.
 
-{.deprecated: [FReadEnv: ReadEnvEffect, FWriteEnv: WriteEnvEffect, 
+{.deprecated: [FReadEnv: ReadEnvEffect, FWriteEnv: WriteEnvEffect,
     FReadDir: ReadDirEffect,
     FWriteDir: WriteDirEffect,
     TOSErrorCode: OSErrorCode
@@ -801,13 +801,13 @@ when defined(Windows):
 
     when useWinUnicode:
       result = createFileW(
-        newWideCString(path), 0'i32, 
+        newWideCString(path), 0'i32,
         FILE_SHARE_DELETE or FILE_SHARE_READ or FILE_SHARE_WRITE,
         nil, OPEN_EXISTING, flags, 0
         )
     else:
       result = createFileA(
-        path, 0'i32, 
+        path, 0'i32,
         FILE_SHARE_DELETE or FILE_SHARE_READ or FILE_SHARE_WRITE,
         nil, OPEN_EXISTING, flags, 0
         )
@@ -924,11 +924,11 @@ proc getFilePermissions*(filename: string): set[FilePermission] {.
       var res = getFileAttributesA(filename)
     if res == -1'i32: raiseOSError(osLastError())
     if (res and FILE_ATTRIBUTE_READONLY) != 0'i32:
-      result = {fpUserExec, fpUserRead, fpGroupExec, fpGroupRead, 
+      result = {fpUserExec, fpUserRead, fpGroupExec, fpGroupRead,
                 fpOthersExec, fpOthersRead}
     else:
       result = {fpUserExec..fpOthersRead}
-  
+
 proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
   rtl, extern: "nos$1", tags: [WriteDirEffect].} =
   ## sets the file permissions for `filename`. `OSError` is raised in case of
@@ -939,15 +939,15 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
     if fpUserRead in permissions: p = p or S_IRUSR
     if fpUserWrite in permissions: p = p or S_IWUSR
     if fpUserExec in permissions: p = p or S_IXUSR
-    
+
     if fpGroupRead in permissions: p = p or S_IRGRP
     if fpGroupWrite in permissions: p = p or S_IWGRP
     if fpGroupExec in permissions: p = p or S_IXGRP
-    
+
     if fpOthersRead in permissions: p = p or S_IROTH
     if fpOthersWrite in permissions: p = p or S_IWOTH
     if fpOthersExec in permissions: p = p or S_IXOTH
-    
+
     if chmod(filename, p) != 0: raiseOSError(osLastError())
   else:
     when useWinUnicode:
@@ -955,7 +955,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
     else:
       var res = getFileAttributesA(filename)
     if res == -1'i32: raiseOSError(osLastError())
-    if fpUserWrite in permissions: 
+    if fpUserWrite in permissions:
       res = res and not FILE_ATTRIBUTE_READONLY
     else:
       res = res or FILE_ATTRIBUTE_READONLY
@@ -1030,11 +1030,11 @@ when not declared(ENOENT) and not defined(Windows):
 when defined(Windows):
   when useWinUnicode:
     template deleteFile(file: expr): expr {.immediate.} = deleteFileW(file)
-    template setFileAttributes(file, attrs: expr): expr {.immediate.} = 
+    template setFileAttributes(file, attrs: expr): expr {.immediate.} =
       setFileAttributesW(file, attrs)
   else:
     template deleteFile(file: expr): expr {.immediate.} = deleteFileA(file)
-    template setFileAttributes(file, attrs: expr): expr {.immediate.} = 
+    template setFileAttributes(file, attrs: expr): expr {.immediate.} =
       setFileAttributesA(file, attrs)
 
 proc removeFile*(file: string) {.rtl, extern: "nos$1", tags: [WriteDirEffect].} =
@@ -1047,7 +1047,7 @@ proc removeFile*(file: string) {.rtl, extern: "nos$1", tags: [WriteDirEffect].} 
     else:
       let f = file
     if deleteFile(f) == 0:
-      if getLastError() == ERROR_ACCESS_DENIED: 
+      if getLastError() == ERROR_ACCESS_DENIED:
         if setFileAttributes(f, FILE_ATTRIBUTE_NORMAL) == 0:
           raiseOSError(osLastError())
         if deleteFile(f) == 0:
@@ -1319,9 +1319,9 @@ iterator walkDirRec*(dir: string, filter={pcFile, pcDir}): string {.
   ## walks over the directory `dir` and yields for each file in `dir`. The
   ## full path for each file is returned.
   ## **Warning**:
-  ## Modifying the directory structure while the iterator 
-  ## is traversing may result in undefined behavior! 
-  ## 
+  ## Modifying the directory structure while the iterator
+  ## is traversing may result in undefined behavior!
+  ##
   ## Walking is recursive. `filter` controls the behaviour of the iterator:
   ##
   ## ---------------------   ---------------------------------------------
@@ -1424,7 +1424,7 @@ proc createSymlink*(src, dest: string) =
   ## by `src`. On most operating systems, will fail if a lonk
   ##
   ## **Warning**:
-  ## Some OS's (such as Microsoft Windows) restrict the creation 
+  ## Some OS's (such as Microsoft Windows) restrict the creation
   ## of symlinks to root users (administrators).
   when defined(Windows):
     let flag = dirExists(src).int32
@@ -1444,7 +1444,7 @@ proc createHardlink*(src, dest: string) =
   ## Create a hard link at `dest` which points to the item specified
   ## by `src`.
   ##
-  ## **Warning**: Most OS's restrict the creation of hard links to 
+  ## **Warning**: Most OS's restrict the creation of hard links to
   ## root users (administrators) .
   when defined(Windows):
     when useWinUnicode:
@@ -1548,7 +1548,7 @@ proc parseCmdLine*(c: string): seq[string] {.
           add(a, c[i])
           inc(i)
     add(result, a)
-  
+
 proc copyFileWithPermissions*(source, dest: string,
                               ignorePermissionErrors = true) =
   ## Copies a file from `source` to `dest` preserving file permissions.
@@ -1936,10 +1936,10 @@ template rawToFormalFileInfo(rawInfo, formalInfo): expr =
     formalInfo.lastAccessTime = toTime(rawInfo.ftLastAccessTime)
     formalInfo.lastWriteTime = toTime(rawInfo.ftLastWriteTime)
     formalInfo.creationTime = toTime(rawInfo.ftCreationTime)
-    
+
     # Retrieve basic permissions
     if (rawInfo.dwFileAttributes and FILE_ATTRIBUTE_READONLY) != 0'i32:
-      formalInfo.permissions = {fpUserExec, fpUserRead, fpGroupExec, 
+      formalInfo.permissions = {fpUserExec, fpUserRead, fpGroupExec,
                                 fpGroupRead, fpOthersExec, fpOthersRead}
     else:
       result.permissions = {fpUserExec..fpOthersRead}
@@ -1953,7 +1953,7 @@ template rawToFormalFileInfo(rawInfo, formalInfo): expr =
 
 
   else:
-    template checkAndIncludeMode(rawMode, formalMode: expr) = 
+    template checkAndIncludeMode(rawMode, formalMode: expr) =
       if (rawInfo.st_mode and rawMode) != 0'i32:
         formalInfo.permissions.incl(formalMode)
     formalInfo.id = (rawInfo.st_dev, rawInfo.st_ino)
@@ -1992,7 +1992,7 @@ proc getFileInfo*(handle: FileHandle): FileInfo =
     # We have to use the super special '_get_osfhandle' call (wrapped above)
     # To transform the C file descripter to a native file handle.
     var realHandle = get_osfhandle(handle)
-    if getFileInformationByHandle(realHandle, addr rawInfo) == 0:
+    if getFileInformationByHandle(realHandle, addr(rawInfo)) == 0:
       raiseOSError(osLastError())
     rawToFormalFileInfo(rawInfo, result)
   else:
@@ -2008,25 +2008,25 @@ proc getFileInfo*(file: File): FileInfo =
 
 proc getFileInfo*(path: string, followSymlink = true): FileInfo =
   ## Retrieves file information for the file object pointed to by `path`.
-  ## 
+  ##
   ## Due to intrinsic differences between operating systems, the information
   ## contained by the returned `FileInfo` structure will be slightly different
   ## across platforms, and in some cases, incomplete or inaccurate.
-  ## 
+  ##
   ## When `followSymlink` is true, symlinks are followed and the information
   ## retrieved is information related to the symlink's target. Otherwise,
   ## information on the symlink itself is retrieved.
-  ## 
+  ##
   ## If the information cannot be retrieved, such as when the path doesn't
   ## exist, or when permission restrictions prevent the program from retrieving
   ## file information, an error will be thrown.
   when defined(Windows):
-    var 
+    var
       handle = openHandle(path, followSymlink)
       rawInfo: TBY_HANDLE_FILE_INFORMATION
     if handle == INVALID_HANDLE_VALUE:
       raiseOSError(osLastError())
-    if getFileInformationByHandle(handle, addr rawInfo) == 0:
+    if getFileInformationByHandle(handle, addr(rawInfo)) == 0:
       raiseOSError(osLastError())
     rawToFormalFileInfo(rawInfo, result)
     discard closeHandle(handle)
@@ -2044,7 +2044,7 @@ proc isHidden*(path: string): bool =
   ## Determines whether a given path is hidden or not. Returns false if the
   ## file doesn't exist. The given path must be accessible from the current
   ## working directory of the program.
-  ## 
+  ##
   ## On Windows, a file is hidden if the file's 'hidden' attribute is set.
   ## On Unix-like systems, a file is hidden if it starts with a '.' (period)
   ## and is not *just* '.' or '..' ' ."

--- a/lib/pure/rawsockets.nim
+++ b/lib/pure/rawsockets.nim
@@ -41,7 +41,7 @@ export
 
 type
   Port* = distinct uint16  ## port type
-  
+
   Domain* = enum    ## domain, which specifies the protocol family of the
                     ## created socket. Other domains than those that are listed
                     ## here are unsupported.
@@ -56,7 +56,7 @@ type
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
   Protocol* = enum      ## third argument to `socket` proc
-    IPPROTO_TCP = 6,    ## Transmission control protocol. 
+    IPPROTO_TCP = 6,    ## Transmission control protocol.
     IPPROTO_UDP = 17,   ## User datagram protocol.
     IPPROTO_IP,         ## Internet protocol. Unsupported on Windows.
     IPPROTO_IPV6,       ## Internet Protocol Version 6. Unsupported on Windows.
@@ -86,10 +86,10 @@ when useWinVersion:
   const
     IOCPARM_MASK* = 127
     IOC_IN* = int(-2147483648)
-    FIONBIO* = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or 
+    FIONBIO* = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or
                              (102 shl 8) or 126
 
-  proc ioctlsocket*(s: SocketHandle, cmd: clong, 
+  proc ioctlsocket*(s: SocketHandle, cmd: clong,
                    argptr: ptr clong): cint {.
                    stdcall, importc: "ioctlsocket", dynlib: "ws2_32.dll".}
 else:
@@ -138,12 +138,12 @@ when not useWinVersion:
     else: discard
 
 else:
-  proc toInt(domain: Domain): cint = 
+  proc toInt(domain: Domain): cint =
     result = toU16(ord(domain))
 
   proc toInt(typ: SockType): cint =
     result = cint(ord(typ))
-  
+
   proc toInt(p: Protocol): cint =
     result = cint(ord(p))
 
@@ -173,8 +173,8 @@ proc bindAddr*(socket: SocketHandle, name: ptr SockAddr, namelen: SockLen): cint
   result = bindSocket(socket, name, namelen)
 
 proc listen*(socket: SocketHandle, backlog = SOMAXCONN): cint {.tags: [ReadIOEffect].} =
-  ## Marks ``socket`` as accepting connections. 
-  ## ``Backlog`` specifies the maximum length of the 
+  ## Marks ``socket`` as accepting connections.
+  ## ``Backlog`` specifies the maximum length of the
   ## queue of pending connections.
   when useWinVersion:
     result = winlean.listen(socket, cint(backlog))
@@ -201,7 +201,7 @@ proc getAddrInfo*(address: string, port: Port, af: Domain = AF_INET, typ: SockTy
 proc dealloc*(ai: ptr AddrInfo) =
   freeaddrinfo(ai)
 
-proc ntohl*(x: int32): int32 = 
+proc ntohl*(x: int32): int32 =
   ## Converts 32-bit integers from network to host byte order.
   ## On machines where the host byte order is the same as network byte order,
   ## this is a no-op; otherwise, it performs a 4-byte swap operation.
@@ -231,7 +231,7 @@ proc htons*(x: int16): int16 =
   result = rawsockets.ntohs(x)
 
 proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
-  ## Searches the database from the beginning and finds the first entry for 
+  ## Searches the database from the beginning and finds the first entry for
   ## which the service name specified by ``name`` matches the s_name member
   ## and the protocol name specified by ``proto`` matches the s_proto member.
   ##
@@ -245,10 +245,10 @@ proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
   result.aliases = cstringArrayToSeq(s.s_aliases)
   result.port = Port(s.s_port)
   result.proto = $s.s_proto
-  
-proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} = 
-  ## Searches the database from the beginning and finds the first entry for 
-  ## which the port specified by ``port`` matches the s_port member and the 
+
+proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} =
+  ## Searches the database from the beginning and finds the first entry for
+  ## which the port specified by ``port`` matches the s_port member and the
   ## protocol name specified by ``proto`` matches the s_proto member.
   ##
   ## On posix this will search through the ``/etc/services`` file.
@@ -266,17 +266,17 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the hostname of an IP Address.
   var myaddr: InAddr
   myaddr.s_addr = inet_addr(ip)
-  
+
   when useWinVersion:
     var s = winlean.gethostbyaddr(addr(myaddr), sizeof(myaddr).cuint,
                                   cint(rawsockets.AF_INET))
     if s == nil: raiseOSError(osLastError())
   else:
-    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen, 
+    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen,
                                 cint(posix.AF_INET))
     if s == nil:
       raise newException(OSError, $hstrerror(h_errno))
-  
+
   result.name = $s.h_name
   result.aliases = cstringArrayToSeq(s.h_aliases)
   when useWinVersion:
@@ -291,7 +291,7 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
 
-proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} = 
+proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the IP address of a hostname.
   when useWinVersion:
     var s = winlean.gethostbyname(name)
@@ -312,7 +312,7 @@ proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
 
-proc getSockName*(socket: SocketHandle): Port = 
+proc getSockName*(socket: SocketHandle): Port =
   ## returns the socket's associated port number.
   var name: Sockaddr_in
   when useWinVersion:
@@ -328,11 +328,11 @@ proc getSockName*(socket: SocketHandle): Port =
   result = Port(rawsockets.ntohs(name.sin_port))
 
 proc getSockOptInt*(socket: SocketHandle, level, optname: int): int {.
-  tags: [ReadIOEffect].} = 
+  tags: [ReadIOEffect].} =
   ## getsockopt for integer options.
   var res: cint
   var size = sizeof(res).SockLen
-  if getsockopt(socket, cint(level), cint(optname), 
+  if getsockopt(socket, cint(level), cint(optname),
                 addr(res), addr(size)) < 0'i32:
     raiseOSError(osLastError())
   result = int(res)
@@ -341,7 +341,7 @@ proc setSockOptInt*(socket: SocketHandle, level, optname, optval: int) {.
   tags: [WriteIOEffect].} =
   ## setsockopt for integer options.
   var value = cint(optval)
-  if setsockopt(socket, cint(level), cint(optname), addr(value),  
+  if setsockopt(socket, cint(level), cint(optname), addr(value),
                 sizeof(value).SockLen) < 0'i32:
     raiseOSError(osLastError())
 
@@ -368,13 +368,13 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var TFdSet, s: seq[SocketHandle], m: var int) = 
+proc createFdSet(fd: var TFdSet, s: seq[SocketHandle], m: var int) =
   FD_ZERO(fd)
-  for i in items(s): 
+  for i in items(s):
     m = max(m, int(i))
     FD_SET(i, fd)
-   
-proc pruneSocketSet(s: var seq[SocketHandle], fd: var TFdSet) = 
+
+proc pruneSocketSet(s: var seq[SocketHandle], fd: var TFdSet) =
   var i = 0
   var L = s.len
   while i < L:
@@ -388,22 +388,22 @@ proc pruneSocketSet(s: var seq[SocketHandle], fd: var TFdSet) =
 proc select*(readfds: var seq[SocketHandle], timeout = 500): int =
   ## Traditional select function. This function will return the number of
   ## sockets that are ready to be read from, written to, or which have errors.
-  ## If there are none; 0 is returned. 
+  ## If there are none; 0 is returned.
   ## ``Timeout`` is in miliseconds and -1 can be specified for no timeout.
-  ## 
+  ##
   ## A socket is removed from the specific ``seq`` when it has data waiting to
   ## be read/written to or has errors (``exceptfds``).
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var rd: TFdSet
   var m = 0
   createFdSet((rd), readfds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), addr(rd), nil, nil, addr(tv)))
   else:
     result = int(select(cint(m+1), addr(rd), nil, nil, nil))
-  
+
   pruneSocketSet(readfds, (rd))
 
 proc selectWrite*(writefds: var seq[SocketHandle],
@@ -416,16 +416,16 @@ proc selectWrite*(writefds: var seq[SocketHandle],
   ## ``timeout`` is specified in miliseconds and ``-1`` can be specified for
   ## an unlimited time.
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var wr: TFdSet
   var m = 0
   createFdSet((wr), writefds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), nil, addr(wr), nil, addr(tv)))
   else:
     result = int(select(cint(m+1), nil, addr(wr), nil, nil))
-  
+
   pruneSocketSet(writefds, (wr))
 
 # We ignore signal SIGPIPE on Darwin
@@ -434,4 +434,4 @@ when defined(macosx):
 
 when defined(Windows):
   var wsa: WSAData
-  if wsaStartup(0x0101'i16, addr wsa) != 0: raiseOSError(osLastError())
+  if wsaStartup(0x0101'i16, addr(wsa)) != 0: raiseOSError(osLastError())

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -11,11 +11,11 @@
 
 import tables, os, unsigned, hashes
 
-when defined(linux): 
+when defined(linux):
   import posix, epoll
-elif defined(windows): 
+elif defined(windows):
   import winlean
-else: 
+else:
   import posix
 
 proc hash*(x: SocketHandle): THash {.borrow.}
@@ -76,7 +76,7 @@ elif defined(linux):
       epollFD: cint
       events: array[64, epoll_event]
       fds: Table[SocketHandle, SelectorKey]
-  
+
   proc createEventStruct(events: set[Event], fd: SocketHandle): epoll_event =
     if EvRead in events:
       result.events = EPOLLIN
@@ -84,7 +84,7 @@ elif defined(linux):
       result.events = result.events or EPOLLOUT
     result.events = result.events or EPOLLRDHUP
     result.data.fd = fd.cint
-  
+
   proc register*(s: Selector, fd: SocketHandle, events: set[Event],
       data: RootRef): SelectorKey {.discardable.} =
     var event = createEventStruct(events, fd)
@@ -93,10 +93,10 @@ elif defined(linux):
         raiseOSError(osLastError())
 
     var key = SelectorKey(fd: fd, events: events, data: data)
-  
+
     s.fds[fd] = key
     result = key
-  
+
   proc update*(s: Selector, fd: SocketHandle,
       events: set[Event]): SelectorKey {.discardable.} =
     if s.fds[fd].events != events:
@@ -120,9 +120,9 @@ elif defined(linux):
           if epoll_ctl(s.epollFD, EPOLL_CTL_MOD, fd, addr(event)) != 0:
             raiseOSError(osLastError())
         s.fds[fd].events = events
-      
+
       result = s.fds[fd]
-  
+
   proc unregister*(s: Selector, fd: SocketHandle): SelectorKey {.discardable.} =
     if epoll_ctl(s.epollFD, EPOLL_CTL_DEL, fd, nil) != 0:
       let err = osLastError()
@@ -133,8 +133,8 @@ elif defined(linux):
 
   proc close*(s: Selector) =
     if s.epollFD.close() != 0: raiseOSError(osLastError())
-    dealloc(addr s.events) # TODO: Test this
-  
+    dealloc(addr(s.events)) # TODO: Test this
+
   proc epollHasFd(s: Selector, fd: SocketHandle): bool =
     result = true
     var event = createEventStruct(s.fds[fd].events, fd)
@@ -143,7 +143,7 @@ elif defined(linux):
       if err.cint in {ENOENT, EBADF}:
         return false
       raiseOSError(osLastError())
-  
+
   proc select*(s: Selector, timeout: int): seq[ReadyInfo] =
     ##
     ## The ``events`` field of the returned ``key`` contains the original events
@@ -151,7 +151,7 @@ elif defined(linux):
     ## of the ``TReadyInfo`` tuple which determines which events are ready
     ## on the ``fd``.
     result = @[]
-    let evNum = epoll_wait(s.epollFD, addr s.events[0], 64.cint, timeout.cint)
+    let evNum = epoll_wait(s.epollFD, addr(s.events[0]), 64.cint, timeout.cint)
     if evNum < 0:
       let err = osLastError()
       if err.cint == EINTR:
@@ -160,7 +160,7 @@ elif defined(linux):
     if evNum == 0: return @[]
     for i in 0 .. <evNum:
       let fd = s.events[i].data.fd.SocketHandle
-    
+
       var evSet: set[Event] = {}
       if (s.events[i].events and EPOLLERR) != 0 or (s.events[i].events and EPOLLHUP) != 0: evSet = evSet + {EvError}
       if (s.events[i].events and EPOLLIN) != 0: evSet = evSet + {EvRead}
@@ -170,7 +170,7 @@ elif defined(linux):
       result.add((selectorKey, evSet))
 
       #echo("Epoll: ", result[i].key.fd, " ", result[i].events, " ", result[i].key.events)
-  
+
   proc newSelector*(): Selector =
     new result
     result.epollFD = epoll_create(64)
@@ -232,13 +232,13 @@ elif not defined(nimdoc):
       m: var int) =
     FD_ZERO(rd); FD_ZERO(wr)
     for k, v in pairs(fds):
-      if EvRead in v.events: 
+      if EvRead in v.events:
         m = max(m, int(k))
         FD_SET(k, rd)
       if EvWrite in v.events:
         m = max(m, int(k))
         FD_SET(k, wr)
-     
+
   proc getReadyFDs(rd, wr: var TFdSet, fds: Table[SocketHandle, SelectorKey]):
       seq[ReadyInfo] =
     result = @[]
@@ -253,17 +253,17 @@ elif not defined(nimdoc):
   proc select(fds: Table[SocketHandle, SelectorKey], timeout = 500):
     seq[ReadyInfo] =
     var tv {.noInit.}: TimeVal = timeValFromMilliseconds(timeout)
-    
+
     var rd, wr: TFdSet
     var m = 0
     createFdSet(rd, wr, fds, m)
-    
+
     var retCode = 0
     if timeout != -1:
       retCode = int(select(cint(m+1), addr(rd), addr(wr), nil, addr(tv)))
     else:
       retCode = int(select(cint(m+1), addr(rd), addr(wr), nil, nil))
-    
+
     if retCode < 0:
       raiseOSError(osLastError())
     elif retCode == 0:
@@ -302,12 +302,12 @@ when isMainModule and not defined(nimdoc):
   type
     SockWrapper = ref object of RootObj
       sock: Socket
-  
+
   var sock = socket()
   if sock == sockets.invalidSocket: raiseOSError(osLastError())
   #sock.setBlocking(false)
   sock.connect("irc.freenode.net", Port(6667))
-  
+
   var selector = newSelector()
   var data = SockWrapper(sock: sock)
   let key = selector.register(sock.getFD, {EvWrite}, data)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -50,14 +50,14 @@ else:
 
   proc setRaw(fd: FileHandle, time: cint = TCSAFLUSH) =
     var mode: Termios
-    discard fd.tcgetattr(addr mode)
+    discard fd.tcgetattr(addr(mode))
     mode.iflag = mode.iflag and not Tcflag(BRKINT or ICRNL or INPCK or ISTRIP or IXON)
     mode.oflag = mode.oflag and not Tcflag(OPOST)
     mode.cflag = (mode.cflag and not Tcflag(CSIZE or PARENB)) or CS8
     mode.lflag = mode.lflag and not Tcflag(ECHO or ICANON or IEXTEN or ISIG)
     mode.cc[VMIN] = 1.cuchar
     mode.cc[VTIME] = 0.cuchar
-    discard fd.tcsetattr(time, addr mode)
+    discard fd.tcsetattr(time, addr(mode))
 
 proc setCursorPos*(x, y: int) =
   ## sets the terminal's cursor to the (x,y) position. (0,0) is the
@@ -370,10 +370,10 @@ when not defined(windows):
     ## Windows.
     let fd = getFileHandle(stdin)
     var oldMode: Termios
-    discard fd.tcgetattr(addr oldMode)
+    discard fd.tcgetattr(addr(oldMode))
     fd.setRaw()
     result = stdin.readChar()
-    discard fd.tcsetattr(TCSADRAIN, addr oldMode)
+    discard fd.tcsetattr(TCSADRAIN, addr(oldMode))
 
 when isMainModule:
   system.addQuitProc(resetAttributes)

--- a/lib/system/atomics.nim
+++ b/lib/system/atomics.nim
@@ -21,19 +21,19 @@ when someGcc and hasThreadSupport:
     ## synchronization with another thread.
   var ATOMIC_ACQUIRE* {.importc: "__ATOMIC_ACQUIRE", nodecl.}: AtomMemModel
     ## Barrier to hoisting of code and synchronizes with
-    ## release (or stronger) 
+    ## release (or stronger)
     ## semantic stores from another thread.
   var ATOMIC_RELEASE* {.importc: "__ATOMIC_RELEASE", nodecl.}: AtomMemModel
     ## Barrier to sinking of code and synchronizes with
-    ## acquire (or stronger) 
-    ## semantic loads from another thread. 
+    ## acquire (or stronger)
+    ## semantic loads from another thread.
   var ATOMIC_ACQ_REL* {.importc: "__ATOMIC_ACQ_REL", nodecl.}: AtomMemModel
     ## Full barrier in both directions and synchronizes
-    ## with acquire loads 
+    ## with acquire loads
     ## and release stores in another thread.
   var ATOMIC_SEQ_CST* {.importc: "__ATOMIC_SEQ_CST", nodecl.}: AtomMemModel
     ## Full barrier in both directions and synchronizes
-    ## with acquire loads 
+    ## with acquire loads
     ## and release stores in all threads.
 
   type
@@ -46,11 +46,11 @@ when someGcc and hasThreadSupport:
     ## ATOMIC_RELAXED, ATOMIC_SEQ_CST, ATOMIC_ACQUIRE, ATOMIC_CONSUME.
 
   proc atomicLoad*[T: TAtomType](p, ret: ptr T, mem: AtomMemModel) {.
-    importc: "__atomic_load", nodecl.}  
+    importc: "__atomic_load", nodecl.}
     ## This is the generic version of an atomic load. It returns the contents at p in ret.
 
   proc atomicStoreN*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel) {.
-    importc: "__atomic_store_n", nodecl.} 
+    importc: "__atomic_store_n", nodecl.}
     ## This proc implements an atomic store operation. It writes val at p.
     ## ATOMIC_RELAXED, ATOMIC_SEQ_CST, and ATOMIC_RELEASE.
 
@@ -60,39 +60,39 @@ when someGcc and hasThreadSupport:
 
   proc atomicExchangeN*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_exchange_n", nodecl.}
-    ## This proc implements an atomic exchange operation. It writes val at p, 
+    ## This proc implements an atomic exchange operation. It writes val at p,
     ## and returns the previous contents at p.
     ## ATOMIC_RELAXED, ATOMIC_SEQ_CST, ATOMIC_ACQUIRE, ATOMIC_RELEASE, ATOMIC_ACQ_REL
 
   proc atomicExchange*[T: TAtomType](p, val, ret: ptr T, mem: AtomMemModel) {.
     importc: "__atomic_exchange", nodecl.}
-    ## This is the generic version of an atomic exchange. It stores the contents at val at p. 
+    ## This is the generic version of an atomic exchange. It stores the contents at val at p.
     ## The original value at p is copied into ret.
 
   proc atomicCompareExchangeN*[T: TAtomType](p, expected: ptr T, desired: T,
     weak: bool, success_memmodel: AtomMemModel, failure_memmodel: AtomMemModel): bool {.
-    importc: "__atomic_compare_exchange_n ", nodecl.} 
+    importc: "__atomic_compare_exchange_n ", nodecl.}
     ## This proc implements an atomic compare and exchange operation. This compares the
-    ## contents at p with the contents at expected and if equal, writes desired at p. 
-    ## If they are not equal, the current contents at p is written into expected. 
-    ## Weak is true for weak compare_exchange, and false for the strong variation. 
-    ## Many targets only offer the strong variation and ignore the parameter. 
+    ## contents at p with the contents at expected and if equal, writes desired at p.
+    ## If they are not equal, the current contents at p is written into expected.
+    ## Weak is true for weak compare_exchange, and false for the strong variation.
+    ## Many targets only offer the strong variation and ignore the parameter.
     ## When in doubt, use the strong variation.
-    ## True is returned if desired is written at p and the execution is considered 
-    ## to conform to the memory model specified by success_memmodel. There are no 
-    ## restrictions on what memory model can be used here. False is returned otherwise, 
-    ## and the execution is considered to conform to failure_memmodel. This memory model 
-    ## cannot be __ATOMIC_RELEASE nor __ATOMIC_ACQ_REL. It also cannot be a stronger model 
+    ## True is returned if desired is written at p and the execution is considered
+    ## to conform to the memory model specified by success_memmodel. There are no
+    ## restrictions on what memory model can be used here. False is returned otherwise,
+    ## and the execution is considered to conform to failure_memmodel. This memory model
+    ## cannot be __ATOMIC_RELEASE nor __ATOMIC_ACQ_REL. It also cannot be a stronger model
     ## than that specified by success_memmodel.
 
   proc atomicCompareExchange*[T: TAtomType](p, expected, desired: ptr T,
     weak: bool, success_memmodel: AtomMemModel, failure_memmodel: AtomMemModel): bool {.
-    importc: "__atomic_compare_exchange_n ", nodecl.}  
-    ## This proc implements the generic version of atomic_compare_exchange. 
-    ## The proc is virtually identical to atomic_compare_exchange_n, except the desired 
-    ## value is also a pointer. 
+    importc: "__atomic_compare_exchange_n ", nodecl.}
+    ## This proc implements the generic version of atomic_compare_exchange.
+    ## The proc is virtually identical to atomic_compare_exchange_n, except the desired
+    ## value is also a pointer.
 
-  ## Perform the operation return the new value, all memory models are valid 
+  ## Perform the operation return the new value, all memory models are valid
   proc atomicAddFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_add_fetch", nodecl.}
   proc atomicSubFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
@@ -101,64 +101,64 @@ when someGcc and hasThreadSupport:
     importc: "__atomic_or_fetch ", nodecl.}
   proc atomicAndFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_and_fetch", nodecl.}
-  proc atomicXorFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.   
+  proc atomicXorFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_xor_fetch", nodecl.}
-  proc atomicNandFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.   
-    importc: "__atomic_nand_fetch ", nodecl.} 
+  proc atomicNandFetch*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
+    importc: "__atomic_nand_fetch ", nodecl.}
 
-  ## Perform the operation return the old value, all memory models are valid 
+  ## Perform the operation return the old value, all memory models are valid
   proc atomicFetchAdd*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_fetch_add", nodecl.}
-  proc atomicFetchSub*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.  
+  proc atomicFetchSub*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_fetch_sub", nodecl.}
-  proc atomicFetchOr*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.  
+  proc atomicFetchOr*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_fetch_or", nodecl.}
-  proc atomicFetchAnd*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.   
+  proc atomicFetchAnd*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_fetch_and", nodecl.}
-  proc atomicFetchXor*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.  
+  proc atomicFetchXor*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
     importc: "__atomic_fetch_xor", nodecl.}
-  proc atomicFetchNand*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.  
-    importc: "__atomic_fetch_nand", nodecl.} 
+  proc atomicFetchNand*[T: TAtomType](p: ptr T, val: T, mem: AtomMemModel): T {.
+    importc: "__atomic_fetch_nand", nodecl.}
 
-  proc atomicTestAndSet*(p: pointer, mem: AtomMemModel): bool {.  
-    importc: "__atomic_test_and_set", nodecl.} 
-    ## This built-in function performs an atomic test-and-set operation on the byte at p. 
+  proc atomicTestAndSet*(p: pointer, mem: AtomMemModel): bool {.
+    importc: "__atomic_test_and_set", nodecl.}
+    ## This built-in function performs an atomic test-and-set operation on the byte at p.
     ## The byte is set to some implementation defined nonzero “set” value and the return
     ## value is true if and only if the previous contents were “set”.
     ## All memory models are valid.
 
-  proc atomicClear*(p: pointer, mem: AtomMemModel) {.  
+  proc atomicClear*(p: pointer, mem: AtomMemModel) {.
     importc: "__atomic_clear", nodecl.}
-    ## This built-in function performs an atomic clear operation at p. 
+    ## This built-in function performs an atomic clear operation at p.
     ## After the operation, at p contains 0.
     ## ATOMIC_RELAXED, ATOMIC_SEQ_CST, ATOMIC_RELEASE
 
-  proc atomicThreadFence*(mem: AtomMemModel) {.  
+  proc atomicThreadFence*(mem: AtomMemModel) {.
     importc: "__atomic_thread_fence", nodecl.}
-    ## This built-in function acts as a synchronization fence between threads based 
+    ## This built-in function acts as a synchronization fence between threads based
     ## on the specified memory model. All memory orders are valid.
 
-  proc atomicSignalFence*(mem: AtomMemModel) {.  
+  proc atomicSignalFence*(mem: AtomMemModel) {.
     importc: "__atomic_signal_fence", nodecl.}
-    ## This built-in function acts as a synchronization fence between a thread and 
+    ## This built-in function acts as a synchronization fence between a thread and
     ## signal handlers based in the same thread. All memory orders are valid.
 
-  proc atomicAlwaysLockFree*(size: int, p: pointer): bool {.  
+  proc atomicAlwaysLockFree*(size: int, p: pointer): bool {.
     importc: "__atomic_always_lock_free", nodecl.}
-    ## This built-in function returns true if objects of size bytes always generate 
-    ## lock free atomic instructions for the target architecture. size must resolve 
+    ## This built-in function returns true if objects of size bytes always generate
+    ## lock free atomic instructions for the target architecture. size must resolve
     ## to a compile-time constant and the result also resolves to a compile-time constant.
-    ## ptr is an optional pointer to the object that may be used to determine alignment. 
-    ## A value of 0 indicates typical alignment should be used. The compiler may also 
+    ## ptr is an optional pointer to the object that may be used to determine alignment.
+    ## A value of 0 indicates typical alignment should be used. The compiler may also
     ## ignore this parameter.
 
-  proc atomicIsLockFree*(size: int, p: pointer): bool {.  
+  proc atomicIsLockFree*(size: int, p: pointer): bool {.
     importc: "__atomic_is_lock_free", nodecl.}
-    ## This built-in function returns true if objects of size bytes always generate 
-    ## lock free atomic instructions for the target architecture. If it is not known 
+    ## This built-in function returns true if objects of size bytes always generate
+    ## lock free atomic instructions for the target architecture. If it is not known
     ## to be lock free a call is made to a runtime routine named __atomic_is_lock_free.
-    ## ptr is an optional pointer to the object that may be used to determine alignment. 
-    ## A value of 0 indicates typical alignment should be used. The compiler may also 
+    ## ptr is an optional pointer to the object that may be used to determine alignment.
+    ## A value of 0 indicates typical alignment should be used. The compiler may also
     ## ignore this parameter.
 
   template fence*() = atomicThreadFence(ATOMIC_SEQ_CST)
@@ -178,7 +178,7 @@ proc atomicInc*(memLoc: var int, x: int = 1): int =
   else:
     inc(memLoc, x)
     result = memLoc
-  
+
 proc atomicDec*(memLoc: var int, x: int = 1): int =
   when someGcc and hasThreadSupport:
     when declared(atomic_sub_fetch):
@@ -219,6 +219,6 @@ when not declared(fence) and hasThreadSupport:
   # XXX fixme
   proc fence*() {.inline.} =
     var dummy: bool
-    discard cas(addr dummy, false, true)
+    discard cas(addr(dummy), false, true)
 
 {.pop.}

--- a/lib/system/sysspawn.nim
+++ b/lib/system/sysspawn.nim
@@ -9,7 +9,7 @@
 
 ## Implements Nim's 'spawn'.
 
-when not declared(NimString): 
+when not declared(NimString):
   {.error: "You must not import this module explicitly".}
 
 {.push stackTrace:off.}
@@ -65,7 +65,7 @@ proc createFastCondVar(): FastCondVar =
 
 proc await(cv: var FastCondVar) =
   #for i in 0 .. 50:
-  #  if cas(addr cv.event, true, false):
+  #  if cas(addr(cv.event), true, false):
   #    # this is a HIT: Triggers > 95% in my tests.
   #    return
   #  cpuRelax()
@@ -76,7 +76,7 @@ proc await(cv: var FastCondVar) =
 
 proc signal(cv: var FastCondVar) =
   cv.event = true
-  #if cas(addr cv.slowPath, true, false):
+  #if cas(addr(cv.slowPath), true, false):
   signal(cv.slow)
 
 type
@@ -172,7 +172,7 @@ proc nimSpawn(fn: WorkerProc; data: pointer) {.compilerProc.} =
   while true:
     for i in 0.. high(workers):
       let w = addr(workersData[i])
-      if cas(addr w.ready, true, false):
+      if cas(addr(w.ready), true, false):
         w.data = data
         w.f = fn
         signal(w.taskArrived)

--- a/tests/benchmarks/fannkuch.nim
+++ b/tests/benchmarks/fannkuch.nim
@@ -2,7 +2,7 @@ import os
 import strutils
 
 proc fannkuch (n: int): int =
-    var 
+    var
         count: seq[int]
         maxFlips = 0
         m        = n-1
@@ -50,15 +50,15 @@ proc fannkuch (n: int): int =
         block makePerm:
             while r != n:
                 var tmp = perm1[0]
-                # # perm1.delete (0)
-                # # perm1.insert (tmp, r)
+                # # perm1.delete(0)
+                # # perm1.insert(tmp, r)
                 # # The above is about twice as slow as the following:
-                # moveMem (addr (perm1[0]), addr (perm1[1]), r * sizeof (int))
+                # moveMem (addr(perm1[0]), addr(perm1[1]), r * sizeof(int))
                 # The call to moveMem is about 50% slower than the loop below!
                 for i in 0 .. r-1:
                     perm1[i] = perm1[i+1]
                 perm1[r] = tmp
-                
+
                 dec (count[r])
                 if count[r] > 0:
                     break makePerm

--- a/tests/ccgbugs/tmissingderef.nim
+++ b/tests/ccgbugs/tmissingderef.nim
@@ -13,17 +13,17 @@ type
 proc mainowar =
   var foo: TFoo
   foo.x = 0xff
-  var arr1 = cast[ptr array[4, uint8]](addr foo)[] # Fails.
+  var arr1 = cast[ptr array[4, uint8]](addr(foo))[] # Fails.
   echo arr1[when cpuEndian == littleEndian: 0 else: 3]
 
   var i = 1i32
-  let x = addr i
+  let x = addr(i)
   var arr2 = cast[ptr array[4, uint8]](x)[] # Fails.
   echo arr2[when cpuEndian == littleEndian: 0 else: 3], " ", i
 
   # bug #1715
   var a: array[2, float32] = [0.5'f32, 0.7]
-  let p = addr a
+  let p = addr(a)
   var b = p[]
   echo b[0]
 

--- a/tests/converter/tconvert.nim
+++ b/tests/converter/tconvert.nim
@@ -12,7 +12,7 @@ ImageSurfaceCreate(width, height)
 
 type TFoo = object
 
-converter toPtr*(some: var TFoo): ptr TFoo = (addr some)
+converter toPtr*(some: var TFoo): ptr TFoo = (addr(some))
 
 
 proc zoot(x: ptr TFoo) = nil

--- a/tests/gc/gcleak5.nim
+++ b/tests/gc/gcleak5.nim
@@ -10,13 +10,13 @@ proc main =
     #while true:
     var t = getTime()
     var g = t.getGMTime()
-    #echo isOnStack(addr g)
-    
+    #echo isOnStack(addr(g))
+
     if i mod 100 == 0:
       let om = getOccupiedMem()
       #echo "memory: ", om
       if om > 100_000: quit "leak"
-     
+
     inc(i)
     sleep(1)
 

--- a/tests/generics/tgeneric3.nim
+++ b/tests/generics/tgeneric3.nim
@@ -37,25 +37,25 @@ proc clean[T: SomeOrdinal|SomeNumber](o: var T) {.inline.} = discard
 proc clean[T: string|seq](o: var T) {.inline.} =
   o = nil
 
-proc clean[T,D] (o: ref TItem[T,D]) {.inline.} = 
+proc clean[T,D] (o: ref TItem[T,D]) {.inline.} =
   when (D is string) :
     o.value = nil
   else :
     o.val_set = false
 
-proc isClean[T,D] (it: ref TItem[T,D]): bool {.inline.} = 
+proc isClean[T,D] (it: ref TItem[T,D]): bool {.inline.} =
   when (D is string) :
     return it.value == nil
   else :
     return not it.val_set
 
-proc isClean[T,D](n: PNode[T,D], x: int): bool {.inline.} = 
+proc isClean[T,D](n: PNode[T,D], x: int): bool {.inline.} =
   when (D is string):
     return n.slots[x].value == nil
   else:
     return not n.slots[x].val_set
 
-proc setItem[T,D](Akey: T, Avalue: D, ANode: PNode[T,D]): ref TItem[T,D] {.inline.} = 
+proc setItem[T,D](Akey: T, Avalue: D, ANode: PNode[T,D]): ref TItem[T,D] {.inline.} =
   new(result)
   result.key = Akey
   result.value = Avalue
@@ -72,8 +72,8 @@ template binSearchImpl *(docmp: expr) {.immediate.} =
   var H = haystack.len -1
   while result <= H :
     var I {.inject.} = (result + H) shr 1
-    var SW = docmp 
-    if SW < 0: result = I + 1 
+    var SW = docmp
+    if SW < 0: result = I + 1
     else:
       H = I - 1
       if SW == 0 : bFound = true
@@ -85,14 +85,14 @@ proc bSearch[T,D] (haystack: PNode[T,D], needle:T): int {.inline.} =
 
 proc DeleteItem[T,D] (n: PNode[T,D], x: int): PNode[T,D] {.inline.} =
   var w = n.slots[x]
-  if w.node != nil : 
+  if w.node != nil :
     clean(w)
     return n
   dec(n.count)
   if n.count > 0 :
     for i in countup(x, n.count -1) : n.slots[i] = n.slots[i + 1]
     n.slots[n.count] = nil
-    case n.count 
+    case n.count
     of cLen1 : setLen(n.slots, cLen1)
     of cLen2 : setLen(n.slots, cLen2)
     of cLen3 : setLen(n.slots, cLen3)
@@ -106,7 +106,7 @@ proc DeleteItem[T,D] (n: PNode[T,D], x: int): PNode[T,D] {.inline.} =
     n.slots = nil
     n.left = nil
 
-proc internalDelete[T,D] (ANode: PNode[T,D], key: T, Avalue: var D): PNode[T,D] = 
+proc internalDelete[T,D] (ANode: PNode[T,D], key: T, Avalue: var D): PNode[T,D] =
   var Path: array[0..20, RPath[T,D]]
   var n = ANode
   result = n
@@ -126,20 +126,20 @@ proc internalDelete[T,D] (ANode: PNode[T,D], key: T, Avalue: var D): PNode[T,D] 
           n = n.slots[x].node
         else :
           n = nil
-    else : 
+    else :
       dec(x)
       if isClean(n, x) : return
       Avalue = n.slots[x].value
       var n2 = DeleteItem(n, x)
       dec(h)
       while (n2 != n) and (h >=0) :
-        n = n2 
-        var w = addr Path[h]
+        n = n2
+        var w = addr(Path[h])
         x  = w.Xi -1
         if x >= 0 :
           if (n == nil) and isClean(w.Nd, x) :
             n = w.Nd
-            n.slots[x].node = nil 
+            n.slots[x].node = nil
             n2 = DeleteItem(n, x)
           else :
             w.Nd.slots[x].node = n
@@ -161,7 +161,7 @@ proc internalFind[T,D] (n: PNode[T,D], key: T): ref TItem[T,D] {.inline.} =
         wn = wn.left
       else :
         x = (-x) -1
-        if x < wn.count : 
+        if x < wn.count :
           wn = wn.slots[x].node
         else :
           return nil
@@ -171,7 +171,7 @@ proc internalFind[T,D] (n: PNode[T,D], key: T): ref TItem[T,D] {.inline.} =
   return nil
 
 proc traceTree[T,D](root: PNode[T,D]) =
-  proc traceX(x: int) = 
+  proc traceX(x: int) =
     write stdout, "("
     write stdout, x
     write stdout, ") "
@@ -204,7 +204,7 @@ proc traceTree[T,D](root: PNode[T,D]) =
       if el != nil and not isClean(el):
         traceln(space)
         traceX(i)
-        if i >= n.count: 
+        if i >= n.count:
           write stdout, "error "
         else:
           traceEl(el)
@@ -226,7 +226,7 @@ proc traceTree[T,D](root: PNode[T,D]) =
 proc InsertItem[T,D](APath: RPath[T,D], ANode:PNode[T,D], Akey: T, Avalue: D) =
   var x = - APath.Xi
   inc(APath.Nd.count)
-  case APath.Nd.count 
+  case APath.Nd.count
   of cLen1: setLen(APath.Nd.slots, cLen2)
   of cLen2: setLen(APath.Nd.slots, cLen3)
   of cLen3: setLen(APath.Nd.slots, cLenCenter)
@@ -286,7 +286,7 @@ proc internalPut[T,D](ANode: ref TNode[T,D], Akey: T, Avalue: D, Oldvalue: var D
     if x <= 0 :
       Path[h].Nd = n
       Path[h].Xi = x
-      inc(h) 
+      inc(h)
       if x == 0 :
         n = n.left
       else :
@@ -337,40 +337,40 @@ proc CleanTree[T,D](n: PNode[T,D]): PNode[T,D] =
 proc VisitAllNodes[T,D](n: PNode[T,D], visit: proc(n: PNode[T,D]): PNode[T,D] {.closure.} ): PNode[T,D] =
   if n != nil :
     if n.left != nil :
-      n.left = VisitAllNodes(n.left, visit)    
+      n.left = VisitAllNodes(n.left, visit)
     for i in 0 .. n.count - 1 :
       var w = n.slots[i]
       if w.node != nil :
-        w.node = VisitAllNodes(w.node, visit)    
+        w.node = VisitAllNodes(w.node, visit)
     return visit(n)
   return nil
 
 proc VisitAllNodes[T,D](n: PNode[T,D], visit: proc(n: PNode[T,D]) {.closure.} ) =
   if n != nil:
     if n.left != nil :
-      VisitAllNodes(n.left, visit)    
+      VisitAllNodes(n.left, visit)
     for i in 0 .. n.count - 1 :
       var w = n.slots[i]
       if w.node != nil :
-        VisitAllNodes(w.node, visit)    
+        VisitAllNodes(w.node, visit)
     visit(n)
 
 proc VisitAll[T,D](n: PNode[T,D], visit: proc(Akey: T, Avalue: D) {.closure.} ) =
   if n != nil:
     if n.left != nil :
-      VisitAll(n.left, visit) 
+      VisitAll(n.left, visit)
     for i in 0 .. n.count - 1 :
       var w = n.slots[i]
       if not w.isClean :
-        visit(w.key, w.value)   
+        visit(w.key, w.value)
       if w.node != nil :
-        VisitAll(w.node, visit)    
+        VisitAll(w.node, visit)
 
 proc VisitAll[T,D](n: PNode[T,D], visit: proc(Akey: T, Avalue: var D):bool {.closure.} ): PNode[T,D] =
   if n != nil:
     var n1 = n.left
     if n1 != nil :
-      var n2 = VisitAll(n1, visit) 
+      var n2 = VisitAll(n1, visit)
       if n1 != n2 :
         n.left = n2
     var i = 0
@@ -395,7 +395,7 @@ iterator keys* [T,D] (n: PNode[T,D]): T =
     var level = 0
     var nd = n
     var i = -1
-    while true : 
+    while true :
       if i < nd.count :
         Path[level].Nd = nd
         Path[level].Xi = i
@@ -471,4 +471,4 @@ when isMainModule:
 
 
 
-  test()  
+  test()

--- a/tests/implicit/timplictderef.nim
+++ b/tests/implicit/timplictderef.nim
@@ -12,7 +12,7 @@ type
 
 var x: PValue
 new x
-var sp: PPValue = addr x
+var sp: PPValue = addr(x)
 
 sp.a = 2
 if sp.a == 2: echo 2  # with sp[].a the error is gone

--- a/tests/manyloc/keineschweine/dependencies/enet/testclient.nim
+++ b/tests/manyloc/keineschweine/dependencies/enet/testclient.nim
@@ -12,11 +12,11 @@ client = createHost(nil, 1, 2, 0, 0)
 if client == nil:
   quit "Could not create client!"
 
-if setHost(addr address, "localhost") != 0:
+if setHost(addr(address), "localhost") != 0:
   quit "Could not set host"
 address.port = 8024
 
-peer = client.connect(addr address, 2, 0)
+peer = client.connect(addr(address), 2, 0)
 if peer == nil:
   quit "No available peers"
 

--- a/tests/manyloc/keineschweine/dependencies/enet/testserver.nim
+++ b/tests/manyloc/keineschweine/dependencies/enet/testserver.nim
@@ -11,19 +11,19 @@ address.host = EnetHostAny
 address.port = 8024
 
 server = enet.createHost(
-  addr address, 32, 2,  0,  0)
+  addr(address), 32, 2,  0,  0)
 if server == nil:
   quit "Could not create the server!"
 
-while server.hostService(addr event, 2500) >= 0:
+while server.hostService(addr(event), 2500) >= 0:
   case event.kind
   of EvtConnect:
     echo "New client from $1:$2".format(event.peer.address.host, event.peer.address.port)
-    
+
     var
-      msg = "hello" 
+      msg = "hello"
       resp = createPacket(cstring(msg), msg.len + 1, FlagReliable)
-      
+
     if event.peer.send(0.cuchar, resp) < 0:
       echo "FAILED"
     else:
@@ -32,9 +32,9 @@ while server.hostService(addr event, 2500) >= 0:
     echo "Recvd ($1) $2 ".format(
       event.packet.dataLength,
       event.packet.data)
-    
+
     destroy(event.packet)
-    
+
   of EvtDisconnect:
     echo "Disconnected"
     event.peer.data = nil

--- a/tests/manyloc/keineschweine/dependencies/genpacket/genpacket.nim
+++ b/tests/manyloc/keineschweine/dependencies/genpacket/genpacket.nim
@@ -248,9 +248,9 @@ macro forwardPacket*(typeName: expr, underlyingType: typedesc): stmt {.immediate
 
 template forwardPacketT*(typeName: expr): stmt {.dirty, immediate.} =
   proc `read typeName`*(s: PStream): typeName =
-    discard readData(s, addr result, sizeof(result))
+    discard readData(s, addr(result), sizeof(result))
   proc `pack typeName`*(p: var typeName; s: PStream) =
-    writeData(s, addr p, sizeof(p))
+    writeData(s, addr(p), sizeof(p))
 
 when isMainModule:
   type

--- a/tests/manyloc/keineschweine/dependencies/genpacket/genpacket_enet.nim
+++ b/tests/manyloc/keineschweine/dependencies/genpacket/genpacket_enet.nim
@@ -236,12 +236,12 @@ macro forwardPacket*(typeName: expr, underlyingType: expr): stmt {.immediate.} =
 
 template forwardPacketT*(typeName: expr; underlyingType: expr): stmt {.dirty, immediate.} =
   proc `read typeName`*(buffer: PBuffer): typeName =
-    #discard readData(s, addr result, sizeof(result))
+    #discard readData(s, addr(result), sizeof(result))
     var res: underlyingType
     buffer.read(res)
     result = typeName(res)
   proc `pack`*(buffer: PBuffer; ord: var typeName) =
-    #writeData(s, addr p, sizeof(p))
+    #writeData(s, addr(p), sizeof(p))
     buffer.write(underlyingType(ord))
 
 when isMainModule:

--- a/tests/manyloc/keineschweine/enet_server/server_utils.nim
+++ b/tests/manyloc/keineschweine/enet_server/server_utils.nim
@@ -6,9 +6,9 @@ type
     auth*: bool
     alias*: string
     peer*: PPeer
-  
+
   FileChallengePair* = tuple[challenge: ScFileChallenge; file: TChecksumFile]
-  PFileChallengeSequence* = ref TFileChallengeSequence 
+  PFileChallengeSequence* = ref TFileChallengeSequence
   TFileChallengeSequence = object
     index: int  #which file is active
     transfer: ScFileTransfer
@@ -65,7 +65,7 @@ proc next*(challenge: PFileChallengeSequence, client: PClient) =
     return
   else:
     echo myAssets.len, "assets"
-  challenge.file = addr myAssets[challenge.index]
+  challenge.file = addr(myAssets[challenge.index])
   client.send HFileChallenge, challenge.file.challenge # :rolleyes:
   echo "sent challenge"
 
@@ -73,8 +73,8 @@ proc sendChunk*(challenge: PFileChallengeSequence, client: PClient) =
   let size = min(FileChunkSize, challenge.transfer.fileSize - challenge.transfer.pos)
   challenge.transfer.data.setLen size
   copyMem(
-    addr challenge.transfer.data[0], 
-    addr challenge.file.file.compressed[challenge.transfer.pos],
+    addr(challenge.transfer.data[0]),
+    addr(challenge.file.file.compressed[challenge.transfer.pos]),
     size)
   client.send HFileTransfer, challenge.transfer
   echo "chunk sent"
@@ -90,7 +90,7 @@ proc startSend*(challenge: PFileChallengeSequence, client: PClient) =
 ## HFileTransfer
 proc handleFilePartAck*(client: PClient; buffer: PBuffer) =
   echo "got filepartack"
-  var 
+  var
     ftrans = readCsFilepartAck(buffer)
     fcSeq = fileChallenges[client.id]
   fcSeq.transfer.pos = ftrans.lastPos
@@ -99,7 +99,7 @@ proc handleFilePartAck*(client: PClient; buffer: PBuffer) =
 ## HFileCHallenge
 proc handleFileChallengeResp*(client: PClient; buffer: PBuffer) =
   echo "got file challenge resp"
-  var 
+  var
     fcResp = readCsFileChallenge(buffer)
     fcSeq = fileChallenges[client.id]
   let index = $(fcSeq.index + 1) / $(myAssets.len)

--- a/tests/manyloc/keineschweine/lib/client_helpers.nim
+++ b/tests/manyloc/keineschweine/lib/client_helpers.nim
@@ -1,4 +1,4 @@
-import  
+import
   tables, sg_packets, enet, estreams, sg_gui, sfml,
   zlib_helpers, md5, sg_assets, os
 type
@@ -17,7 +17,7 @@ type
     pos: int32
     data: string
     readyToSave: bool
-var 
+var
   currentFileTransfer: TFileTransfer
   downloadProgress* = newButton(nil, "", vec2f(0,0), nil)
 currentFileTransfer.data = ""
@@ -73,7 +73,7 @@ proc handleFilePartRecv*(serv: PServer; buffer: PBuffer) {.procvar.} =
   var
     f = readScFileTransfer(buffer)
   updateFileProgress()
-  if not(f.pos == currentFileTransfer.pos): 
+  if not(f.pos == currentFileTransfer.pos):
     echo "returning early from filepartrecv"
     return ##issues, probably
   if currentFileTransfer.data.len == 0:
@@ -81,8 +81,8 @@ proc handleFilePartRecv*(serv: PServer; buffer: PBuffer) {.procvar.} =
     currentFileTransfer.data.setLen f.fileSize
   let len = f.data.len
   copymem(
-    addr currentFileTransfer.data[f.pos],
-    addr f.data[0],
+    addr(currentFileTransfer.data[f.pos]),
+    addr(f.data[0]),
     len)
   currentFileTransfer.pos = f.pos + len.int32
   if currentFileTransfer.pos == f.fileSize: #file should be done, rizzight
@@ -100,7 +100,7 @@ proc handleFilePartRecv*(serv: PServer; buffer: PBuffer) {.procvar.} =
 
 proc saveCurrentFile() =
   if not currentFileTransfer.readyToSave: return
-  let 
+  let
     path = expandPath(currentFileTransfer.assetType, currentFileTransfer.fileName)
     parent = parentDir(path)
   if not existsDir(parent):
@@ -123,7 +123,7 @@ proc handleFileChallengeResult*(serv: PServer; buffer: PBuffer) {.procvar.} =
 
 ## HFileCHallenge
 proc handleFileChallenge*(serv: PServer; buffer: PBuffer) {.procvar.} =
-  var 
+  var
     challenge = readScFileChallenge(buffer)
     path = expandPath(challenge)
     resp: CsFileChallenge

--- a/tests/manyloc/keineschweine/lib/estreams.nim
+++ b/tests/manyloc/keineschweine/lib/estreams.nim
@@ -1,6 +1,6 @@
 import endians
 
-proc swapEndian16*(outp, inp: pointer) = 
+proc swapEndian16*(outp, inp: pointer) =
   ## copies `inp` to `outp` swapping bytes. Both buffers are supposed to
   ## contain at least 2 bytes.
   var i = cast[cstring](inp)
@@ -23,7 +23,7 @@ proc newBuffer*(len: int): PBuffer =
 proc newBuffer*(pkt: PPacket): PBuffer =
   new result, free
   result.data = newString(pkt.dataLength)
-  copyMem(addr result.data[0], pkt.data, pkt.dataLength)
+  copyMem(addr(result.data[0]), pkt.data, pkt.dataLength)
 proc toPacket*(buffer: PBuffer; flags: TPacketFlag): PPacket =
   buffer.data.setLen buffer.pos
   result = createPacket(cstring(buffer.data), buffer.pos, flags)
@@ -42,33 +42,33 @@ proc send*(peer: PPeer; channel: cuchar; buf: PBuffer; flags: TPacketFlag): cint
   result = send(peer, channel, buf.toPacket(flags))
 
 proc read*[T: int16|uint16](buffer: PBuffer; outp: var T) =
-  bigEndian16(addr outp, addr buffer.data[buffer.pos])
+  bigEndian16(addr(outp), addr(buffer.data[buffer.pos]))
   inc buffer.pos, 2
 proc read*[T: float32|int32|uint32](buffer: PBuffer; outp: var T) =
-  bigEndian32(addr outp, addr buffer.data[buffer.pos])
+  bigEndian32(addr(outp), addr(buffer.data[buffer.pos]))
   inc buffer.pos, 4
 proc read*[T: float64|int64|uint64](buffer: PBuffer; outp: var T) =
-  bigEndian64(addr outp, addr buffer.data[buffer.pos])
+  bigEndian64(addr(outp), addr(buffer.data[buffer.pos]))
   inc buffer.pos, 8
 proc read*[T: int8|uint8|byte|bool|char](buffer: PBuffer; outp: var T) =
-  copyMem(addr outp, addr buffer.data[buffer.pos], 1)
+  copyMem(addr(outp), addr(buffer.data[buffer.pos]), 1)
   inc buffer.pos, 1
 
 proc writeBE*[T: int16|uint16](buffer: PBuffer; val: var T) =
   setLen buffer.data, buffer.pos + 2
-  bigEndian16(addr buffer.data[buffer.pos], addr val)
+  bigEndian16(addr(buffer.data[buffer.pos]), addr(val))
   inc buffer.pos, 2
 proc writeBE*[T: int32|uint32|float32](buffer: PBuffer; val: var T) =
   setLen buffer.data, buffer.pos + 4
-  bigEndian32(addr buffer.data[buffer.pos], addr val)
+  bigEndian32(addr(buffer.data[buffer.pos]), addr(val))
   inc buffer.pos, 4
 proc writeBE*[T: int64|uint64|float64](buffer: PBuffer; val: var T) =
   setLen buffer.data, buffer.pos + 8
-  bigEndian64(addr buffer.data[buffer.pos], addr val)
+  bigEndian64(addr(buffer.data[buffer.pos]), addr(val))
   inc buffer.pos, 8
 proc writeBE*[T: char|int8|uint8|byte|bool](buffer: PBuffer; val: var T) =
   setLen buffer.data, buffer.pos + 1
-  copyMem(addr buffer.data[buffer.pos], addr val, 1)
+  copyMem(addr(buffer.data[buffer.pos]), addr(val), 1)
   inc buffer.pos, 1
 
 
@@ -76,7 +76,7 @@ proc write*(buffer: PBuffer; val: var string) =
   var length = len(val).uint16
   writeBE buffer, length
   setLen buffer.data, buffer.pos + length.int
-  copyMem(addr buffer.data[buffer.pos], addr val[0], length.int)
+  copyMem(addr(buffer.data[buffer.pos]), addr(val[0]), length.int)
   inc buffer.pos, length.int
 proc write*[T: TNumber|bool|char|byte](buffer: PBuffer; val: T) =
   var v: T
@@ -100,7 +100,7 @@ proc readStr*(buffer: PBuffer): string =
   result = ""
   if len > 0:
     result.setLen len
-    copyMem(addr result[0], addr buffer.data[buffer.pos], len)
+    copyMem(addr(result[0]), addr(buffer.data[buffer.pos]), len)
     inc buffer.pos, len
 proc readChar*(buffer: PBuffer): char {.inline.} = return readInt8(buffer).char
 proc readBool*(buffer: PBuffer): bool {.inline.} = return readInt8(buffer).bool
@@ -113,10 +113,10 @@ when isMainModule:
   echo(repr(b))
   b.pos = 0
   echo(repr(b.readStr()))
-  
+
   b.flush()
   echo "flushed"
   b.writeC([1,2,3])
   echo(repr(b))
-  
-  
+
+

--- a/tests/manyloc/keineschweine/lib/input_helpers.nim
+++ b/tests/manyloc/keineschweine/lib/input_helpers.nim
@@ -2,7 +2,7 @@ import
   sfml, tables, hashes
 type
   TKeyEventKind* = enum down, up
-  TInputFinishedProc* = proc() 
+  TInputFinishedProc* = proc()
   TKeyCallback = proc()
   PKeyClient* = ref object
     onKeyDown: TTable[int32, TKeyCallback]
@@ -18,7 +18,7 @@ var
   activeClient: PKeyClient = nil
   activeInput: PTextInput  = nil
 
-proc setActive*(client: PKeyClient) = 
+proc setActive*(client: PKeyClient) =
   activeClient = client
   echo("** set active client ", client.name)
 proc newKeyClient*(name: string = "unnamed", setactive = false): PKeyClient =
@@ -43,28 +43,28 @@ proc addKeyEvent*(key: TKeyCode, ev: TKeyEventKind) {.inline.} =
   if activeClient.isNil: return
   let k = key.int32
   case ev
-  of down: 
+  of down:
     keyState[k] = true
     if activeClient.onKeyDown.hasKey(k):
       activeClient.onKeyDown[k]()
-  else:    
+  else:
     keyState[k] = false
     if activeClient.onKeyUp.hasKey(k):
       activeClient.onKeyUp[k]()
 proc addButtonEvent*(btn: TMouseButton, ev: TKeyEventKind) {.inline.} =
-  if activeClient.isNil: return 
+  if activeClient.isNil: return
   let b = -btn.int32
   case ev
-  of down: 
-    keyState[b] = true 
+  of down:
+    keyState[b] = true
     if activeClient.onKeyDown.hasKey(b):
       activeClient.onKeyDown[b]()
-  else: 
+  else:
     keyState[b] = false
     if activeClient.onKeyUp.hasKey(b):
       activeClient.onKeyUp[b]()
 proc registerHandler*(client: PKeyClient; key: TKeyCode;
-                       ev: TKeyEventKind; fn: TKeyCallback) = 
+                       ev: TKeyEventKind; fn: TKeyCallback) =
   case ev
   of down: client.onKeyDown[key.int32] = fn
   of up:   client.onKeyUp[key.int32]   = fn
@@ -90,7 +90,7 @@ proc recordText*(i: PTextInput; c: cint) =
   if c > 127 or i.isNil: return
   if c in 32..126: ##printable
     if i.cursor == i.text.len: i.text.add(c.int.chr)
-    else: 
+    else:
       let rem = i.text.substr(i.cursor)
       i.text.setLen(i.cursor)
       i.text.add(chr(c.int))
@@ -104,7 +104,7 @@ proc recordText*(i: PTextInput; c: cint) =
       i.text.add(rem)
   elif c == 10 or c == 13:## \n, \r  enter
     if not i.onEnter.isNil: i.onEnter()
-proc recordText*(i: PTextInput; e: TTextEvent) {.inline.} = 
+proc recordText*(i: PTextInput; e: TTextEvent) {.inline.} =
   recordText(i, e.unicode)
 
 proc setMousePos*(x, y: cint) {.inline.} =
@@ -115,7 +115,7 @@ proc getMousePos*(): TVector2f {.inline.} = result = mousePos
 var event: TEvent
 # Handle and filter input-related events
 iterator filterEvents*(window: PRenderWindow): PEvent =
-  while window.pollEvent(addr event):
+  while window.pollEvent(addr(event)):
     case event.kind
     of EvtKeyPressed: addKeyEvent(event.key.code, down)
     of EvtKeyReleased: addKeyEvent(event.key.code, up)
@@ -123,10 +123,10 @@ iterator filterEvents*(window: PRenderWindow): PEvent =
     of EvtMouseButtonReleased: addButtonEvent(event.mouseButton.button, up)
     of EvtTextEntered: recordText(activeInput, event.text)
     of EvtMouseMoved: setMousePos(event.mouseMove.x, event.mouseMove.y)
-    else: yield(addr event)
+    else: yield(addr(event))
 # Handle and return input-related events
 iterator pollEvents*(window: PRenderWindow): PEvent =
-  while window.pollEvent(addr event):
+  while window.pollEvent(addr(event)):
     case event.kind
     of EvtKeyPressed: addKeyEvent(event.key.code, down)
     of EvtKeyReleased: addKeyEvent(event.key.code, up)
@@ -135,4 +135,4 @@ iterator pollEvents*(window: PRenderWindow): PEvent =
     of EvtTextEntered: recordText(activeInput, event.text)
     of EvtMouseMoved: setMousePos(event.mouseMove.x, event.mouseMove.y)
     else: nil
-    yield(addr event)
+    yield(addr(event))

--- a/tests/manyloc/keineschweine/lib/sg_gui.nim
+++ b/tests/manyloc/keineschweine/lib/sg_gui.nim
@@ -1,5 +1,5 @@
 import
-  sfml, sfml_colors, 
+  sfml, sfml_colors,
   input_helpers, sg_packets
 from strutils import countlines
 {.deadCodeElim: on.}
@@ -63,7 +63,7 @@ proc click*(b: PButton; p: TVector2f)
 proc setPosition*(b: PButton; p: TVector2f)
 proc setString*(b: PButton; s: string) {.inline.}
 
-proc newButton*(container: PGuiContainer; text: string; position: TVector2f; 
+proc newButton*(container: PGuiContainer; text: string; position: TVector2f;
   onClick: TButtonClicked; startEnabled: bool = true): PButton {.discardable.}
 proc init(b: PButton; text: string; position: TVector2f; onClick: TButtonClicked)
 proc setEnabled*(b: PButton; enabled: bool)
@@ -91,7 +91,7 @@ proc newGuiContainer*(): PGuiContainer =
 proc newGuiContainer*(pos: TVector2f): PGuiContainer =
   result = newGuiContainer()
   result.setPosition pos
-proc free*(container: PGuiContainer) = 
+proc free*(container: PGuiContainer) =
   container.widgets = nil
   container.buttons = nil
 proc add*(container: PGuiContainer; widget: PGuiObject) =
@@ -128,9 +128,9 @@ proc newButton*(container: PGuiContainer; text: string;
                  position: TVector2f; onClick: TButtonClicked;
                  startEnabled: bool = true): PButton =
   new(result, free)
-  init(result, 
-       text, 
-       if not container.isNil: position + container.position else: position, 
+  init(result,
+       text,
+       if not container.isNil: position + container.position else: position,
        onClick)
   container.add result
   if not startEnabled: disable(result)
@@ -168,13 +168,13 @@ proc setPosition*(b: PButton, p: TVector2f) =
   b.bounds = b.text.getGlobalBounds()
 proc setString*(b: PButton; s: string) =
   b.text.setString(s)
-proc click*(b: PButton, p: TVector2f) = 
-  if b.enabled and (addr b.bounds).contains(p.x, p.y): 
+proc click*(b: PButton, p: TVector2f) =
+  if b.enabled and (addr(b.bounds)).contains(p.x, p.y):
     b.onClick(b)
 
 proc free(obj: PTextEntry) =
   free(PButton(obj))
-proc newTextEntry*(container: PGuiContainer; text: string; 
+proc newTextEntry*(container: PGuiContainer; text: string;
                     position: TVector2F; onEnter: TInputFinishedProc = nil): PTextEntry =
   new(result, free)
   init(PButton(result), text, position + container.position, proc(b: PButton) =
@@ -210,7 +210,7 @@ proc add*(m: PMessageArea, text: string): PText =
     pos.y -= 16.0
 
 proc draw*(window: PRenderWindow; m: PMessageArea) =
-  let nmsgs = len(m.messages) 
+  let nmsgs = len(m.messages)
   if nmsgs == 0: return
   for i in countdown(nmsgs - 1, max(nmsgs - 30, 0)):
     window.draw(m.messages[i])
@@ -224,11 +224,11 @@ proc newMessageArea*(container: PGuiContainer; position: TVector2f): PMessageAre
   result.scrollBack = 0
   result.direction = -1 ## to push old messages up
   container.add(result)
-  
+
 proc add*(m: PMessageArea, msg: ScChat) =
   const prependName = {CPub, CPriv}
   var mmm: TMessage
-  if msg.kind in prependName: 
+  if msg.kind in prependName:
     mmm.text = "<"
     mmm.text.add msg.fromPlayer
     mmm.text.add "> "
@@ -239,9 +239,9 @@ proc add*(m: PMessageArea, msg: ScChat) =
   of CPub:  mmm.color = RoyalBlue
   of CPriv, CSystem: mmm.color = Green
   of CError: mmm.color = Red
-  
+
   mmm.lines = countLines(mmm.text)+1
-  
+
   m.messages.add mmm
   update m
 proc add*(m: PMessageArea, msg: string) {.inline.} =
@@ -249,7 +249,7 @@ proc add*(m: PMessageArea, msg: string) {.inline.} =
   add(m, chat)
 
 proc proctor*(m: PText; msg: ptr TMessage; pos: ptr TVector2f) =
-  m.setString msg.text 
+  m.setString msg.text
   m.setColor msg.color
   m.setPosition pos[]
 proc update*(m: PMessageArea) =
@@ -263,15 +263,15 @@ proc update*(m: PMessageArea) =
     for i in m.sizeVisible.. < m.texts.len:
       m.texts.pop().destroy()
   let nmsgs = m.messages.len()
-  if m.sizeVisible == 0 or nmsgs == 0: 
+  if m.sizeVisible == 0 or nmsgs == 0:
     echo "no messages? ", m.sizeVisible, ", ", nmsgs
     return
   var pos = vec2f(m.pos.x, m.pos.y)
   for i in 0.. min(m.sizeVisible, nmsgs)-1:
     ##echo nmsgs - i - 1 - m.scrollBack
-    let msg = addr m.messages[nmsgs - i - 1 - m.scrollBack]
-    proctor(m.texts[i], msg, addr pos)
-    pos.y += (16 * m.direction * msg.lines).cfloat  
+    let msg = addr(m.messages[nmsgs - i - 1 - m.scrollBack])
+    proctor(m.texts[i], msg, addr(pos))
+    pos.y += (16 * m.direction * msg.lines).cfloat
 
 proc draw*(window: PRenderWindow; m: PMessageArea) =
   let nmsgs = len(m.texts)

--- a/tests/manyloc/keineschweine/lib/zlib_helpers.nim
+++ b/tests/manyloc/keineschweine/lib/zlib_helpers.nim
@@ -6,7 +6,7 @@ proc compress*(source: string): string =
     destlen = sourcelen + (sourcelen.float * 0.1).int + 16
   result = ""
   result.setLen destLen
-  var res = zlib.compress(cstring(result), addr destLen, cstring(source), sourceLen)
+  var res = zlib.compress(cstring(result), addr(destLen), cstring(source), sourceLen)
   if res != Z_OK:
     echo "Error occurred: ", res
   elif destLen < result.len:
@@ -15,10 +15,10 @@ proc compress*(source: string): string =
 proc uncompress*(source: string, destLen: var int): string =
   result = ""
   result.setLen destLen
-  var res = zlib.uncompress(cstring(result), addr destLen, cstring(source), source.len)
+  var res = zlib.uncompress(cstring(result), addr(destLen), cstring(source), source.len)
   if res != Z_OK:
     echo "Error occurred: ", res
-    
+
 
 when isMainModule:
   import strutils

--- a/tests/manyloc/keineschweine/server/old_dirserver.nim
+++ b/tests/manyloc/keineschweine/server/old_dirserver.nim
@@ -17,7 +17,7 @@ var
   ## I was high.
   clients = initTable[TupAddress, PClient](16)
   alias2client = initTable[string, PClient](32)
-  allClients: seq[PClient] = @[] 
+  allClients: seq[PClient] = @[]
 
 proc findClient*(host: string; port: int16): PClient =
   let addy: TupAddress = (host, port)
@@ -37,7 +37,7 @@ proc loginZone(client: PClient; login: SdZoneLogin): bool =
         result = true
         break
 
-proc sendZoneList(client: PClient) = 
+proc sendZoneList(client: PClient) =
   echo(">> zonelist ", client, ' ', HZoneList)
   client.send(HZonelist, zonelist)
 proc forwardPrivate(rcv: PClient; sender: PClient; txt: string) =
@@ -93,7 +93,7 @@ proc sendServMsg(client: PClient; msg: string) =
   var m = newDsMsg(msg)
   client.send HDsMsg, m
 handlers[HZoneLogin] = proc(client: PClient; stream: PStream) =
-  var 
+  var
     login = readSdZoneLogin(stream)
   if not client.loginZone(login):
     client.sendServMsg "Invalid login"
@@ -110,7 +110,7 @@ handlers[HFileChallenge] = proc(client: PClient; stream: PStream) =
       var chg = readScFileChallenge(stream)
 
 proc handlePkt(s: PClient; stream: PStream) =
-  while not stream.atEnd:  
+  while not stream.atEnd:
     var typ = readChar(stream)
     if not handlers.hasKey(typ):
       break
@@ -128,7 +128,7 @@ var clientIndex = 0
 var incoming = newIncomingBuffer()
 proc poll*(timeout: int = 250) =
   if server.isNil: return
-  var 
+  var
     reads = @[server]
     writes = @[server]
   if select(reads, timeout) > 0:
@@ -163,7 +163,7 @@ when isMainModule:
     case kind
     of cmdShortOption, cmdLongOption:
       case key
-      of "f", "file": 
+      of "f", "file":
         if existsFile(val):
           cfgFile = val
         else:
@@ -177,14 +177,14 @@ when isMainModule:
   zonelist.network = jsonSettings["network"].str
   for slot in jsonSettings["zones"].items:
     zoneSlots.add((slot["name"].str, slot["key"].str))
-  
+
   createServer(port)
   echo("Listening on port ", port, "...")
   var pubChatTimer = cpuTime() #newClock()
   const PubChatDelay = 1000/1000
   while true:
     poll(15)
-    ## TODO sort this type of thing VV into a queue api 
+    ## TODO sort this type of thing VV into a queue api
     if cpuTime() - pubChatTimer > PubChatDelay:       #.getElapsedTime.asMilliseconds > 100:
       pubChatTimer -= pubChatDelay
       if pubChatQueue.getPosition > 0:
@@ -192,10 +192,10 @@ when isMainModule:
         let sizePubChat = pubChatQueue.data.len
         var sent = 0
         filterIt2(allClients, it.auth == true and it.kind == CPlayer):
-          it.outputBuf.writeData(addr pubChatQueue.data[0], sizePubChat)
+          it.outputBuf.writeData(addr(pubChatQueue.data[0]), sizePubChat)
           sent += 1
         #for c in allClients:
-        #  c.outputBuf.writeData(addr pubChatQueue.data[0], sizePubChat)
+        #  c.outputBuf.writeData(addr(pubChatQueue.data[0]), sizePubChat)
         pubChatQueue.flush()
         echo "pubChatQueue flushed to ", sent, "clients"
 

--- a/tests/manyloc/keineschweine/server/old_sg_server.nim
+++ b/tests/manyloc/keineschweine/server/old_sg_server.nim
@@ -9,13 +9,13 @@ var
   ## I was high.
   clients = initTable[TupAddress, PClient](16)
   alias2client = initTable[string, PClient](32)
-  allClients: seq[PClient] = @[] 
-  zonePlayers: seq[PClient] = @[] 
+  allClients: seq[PClient] = @[]
+  zonePlayers: seq[PClient] = @[]
 const
   PubChatDelay = 100/1000 #100 ms
 
 import hashes
-proc hash*(x: uint16): THash {.inline.} = 
+proc hash*(x: uint16): THash {.inline.} =
   result = int32(x)
 
 proc findClient*(host: string; port: int16): PClient =
@@ -27,7 +27,7 @@ proc findClient*(host: string; port: int16): PClient =
   allClients.add(result)
 
 
-proc sendZoneList(client: PClient) = 
+proc sendZoneList(client: PClient) =
   echo(">> zonelist ", client)
   #client.send(HZonelist, zonelist)
 
@@ -83,7 +83,7 @@ handlers[HZoneQuery] = proc(client: PClient; stream: PStream) =
 
 handlers[HZoneJoinReq] = proc(client: PClient; stream: PStream) =
   var req = readCsZoneJoinReq(stream)
-  echo "Join zone request from (",req.session.id,") ", req.session.alias 
+  echo "Join zone request from (",req.session.id,") ", req.session.alias
   if client.auth and client.kind == CPlayer:
     echo "Client is authenticated, verifying filez"
     client.startVerifyingFiles()
@@ -97,7 +97,7 @@ handlers[HZoneJoinReq] = proc(client: PClient; stream: PStream) =
 
 
 proc handlePkt(s: PClient; stream: PStream) =
-  while not stream.atEnd:  
+  while not stream.atEnd:
     var typ = readChar(stream)
     if not handlers.hasKey(typ):
       break
@@ -114,7 +114,7 @@ var clientIndex = 0
 var incoming = newIncomingBuffer()
 proc poll*(timeout: int = 250) =
   if server.isNil: return
-  var 
+  var
     reads = @[server]
     writes = @[server]
   if select(reads, timeout) > 0:
@@ -148,7 +148,7 @@ when isMainModule:
     case kind
     of cmdShortOption, cmdLongOption:
       case key
-      of "f", "file": 
+      of "f", "file":
         if existsFile(val):
           zoneCfgFile = val
         else:
@@ -158,45 +158,45 @@ when isMainModule:
     else:
       echo("Unknown option: ", key, " ", val)
   var jsonSettings = parseFile(zoneCfgFile)
-  let 
+  let
     host = jsonSettings["host"].str
     port = TPort(jsonSettings["port"].num)
     zoneFile = jsonSettings["settings"].str
     dirServerInfo = jsonSettings["dirserver"]
-  
+
   var path = getAppDir()/../"data"/zoneFile
   if not existsFile(path):
     echo("Zone settings file does not exist: ../data/", zoneFile)
     echo(path)
     quit(1)
-  
+
   ## Test file
   block:
-    var 
+    var
       TestFile: FileChallengePair
       contents = repeat("abcdefghijklmnopqrstuvwxyz", 2)
-    testFile.challenge = newScFileChallenge("foobar.test", FZoneCfg, contents.len.int32) 
+    testFile.challenge = newScFileChallenge("foobar.test", FZoneCfg, contents.len.int32)
     testFile.file = checksumStr(contents)
     myAssets.add testFile
-  
+
   setCurrentDir getAppDir().parentDir()
   block:
     let zonesettings = readFile(path)
-    var 
+    var
       errors: seq[string] = @[]
     if not loadSettings(zoneSettings, errors):
       echo("You have errors in your zone settings:")
       for e in errors: echo("**", e)
       quit(1)
     errors.setLen 0
-    
+
     var pair: FileChallengePair
     pair.challenge.file = zoneFile
     pair.challenge.assetType = FZoneCfg
     pair.challenge.fullLen = zoneSettings.len.int32
     pair.file = checksumStr(zoneSettings)
     myAssets.add pair
-    
+
     allAssets:
       if not load(asset):
         echo "Invalid or missing file ", file
@@ -208,10 +208,10 @@ when isMainModule:
           expandPath(assetType, file)).int32
         pair.file = asset.contents
         myAssets.add pair
-        
+
     echo "Zone has ", myAssets.len, " associated assets"
-    
-      
+
+
     dirServer = newServerConnection(dirServerInfo[0].str, dirServerInfo[1].num.TPort)
     dirServer.handlers[HDsMsg] = proc(serv: PServer; stream: PStream) =
       var m = readDsMsg(stream)
@@ -221,18 +221,18 @@ when isMainModule:
       if loggedIn:
         dirServerConnected = true
     dirServer.writePkt HZoneLogin, login
-  
+
   thisZone.name = jsonSettings["name"].str
   thisZone.desc = jsonSettings["desc"].str
   thisZone.ip = "localhost"
   thisZone.port = port
   var login = newSdZoneLogin(
     dirServerInfo[2].str, dirServerInfo[3].str,
-    thisZone)  
+    thisZone)
   #echo "MY LOGIN: ", $login
-  
-  
-  
+
+
+
   createServer(port)
   echo("Listening on port ", port, "...")
   var pubChatTimer = cpuTime()#newClock()
@@ -240,15 +240,15 @@ when isMainModule:
     discard dirServer.pollServer(15)
     poll(15)
     ## TODO sort this type of thing VV into a queue api
-    #let now = cpuTime() 
+    #let now = cpuTime()
     if cpuTime() - pubChatTimer > PubChatDelay:       #.getElapsedTime.asMilliseconds > 100:
       pubChatTimer -= pubChatDelay #.restart()
       if pubChatQueue.getPosition > 0:
         var cn = 0
         let sizePubChat = pubChatQueue.data.len
         for c in allClients:
-          c.outputBuf.writeData(addr pubChatQueue.data[0], sizePubChat)
+          c.outputBuf.writeData(addr(pubChatQueue.data[0]), sizePubChat)
         pubChatQueue.flush()
 
-  
-  
+
+

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/shader.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/shader.nim
@@ -33,7 +33,7 @@ proc newShader*(id: GL_handle): TShader =
 proc shaderInfoLog*(o: TShader): string =
   var log {.global.}: array[0..1024, char]
   var logLen: GLsizei
-  ?glGetShaderInfoLog(o.id.GLuint, log.len.GLsizei, addr logLen, cast[cstring](log.addr))
+  ?glGetShaderInfoLog(o.id.GLuint, log.len.GLsizei, addr(logLen), cast[cstring](log.addr))
   cast[string](log.addr).substr(0, logLen)
 
 proc compile*(shader: TShader, path="") =
@@ -67,7 +67,7 @@ proc attach*(o: TProgram, shader: TShader) =
 proc infoLog*(o: TProgram): string =
   var log {.global.}: array[0..1024, char]
   var logLen: GLsizei
-  ?glGetProgramInfoLog(o.id.GLuint, log.len.GLsizei, addr logLen, cast[cstring](log.addr))
+  ?glGetProgramInfoLog(o.id.GLuint, log.len.GLsizei, addr(logLen), cast[cstring](log.addr))
   cast[string](log.addr).substr(0, logLen)
 
 proc link*(o: TProgram) =

--- a/tests/metatype/tcompositetypeclasses.nim
+++ b/tests/metatype/tcompositetypeclasses.nim
@@ -55,5 +55,5 @@ proc f(src: ptr TUnion, dst: ptr TUnion) =
 var tx: TTest
 var ty: TTest2
 
-accept f(addr tx, addr tx)
-reject f(addr tx, addr ty)
+accept f(addr(tx), addr(tx))
+reject f(addr(tx), addr(ty))

--- a/tests/metatype/ttypebar.nim
+++ b/tests/metatype/ttypebar.nim
@@ -10,5 +10,5 @@ proc f(src: ptr TFoo, dst: ptr TFoo) =
   echo("asd")
 
 var x: TTest
-f(addr x, addr x)
+f(addr(x), addr(x))
 

--- a/tests/parallel/tmissing_deepcopy.nim
+++ b/tests/parallel/tmissing_deepcopy.nim
@@ -21,8 +21,8 @@ proc newPerson(name:string): Person =
 proc greet(p:Person) =
   p.friend.name &= "-MUT" # this line crashes the program
   echo "Person {",
-    " name:", p.name, "(", cast[int](addr p.name),"),",
-    " friend:", p.friend.name, "(", cast[int](addr p.friend.name),") }"
+    " name:", p.name, "(", cast[int](addr(p.name)),"),",
+    " friend:", p.friend.name, "(", cast[int](addr(p.friend.name)),") }"
 
 proc setup =
   for i in 0 .. <20:

--- a/tests/stdlib/tmitems.nim
+++ b/tests/stdlib/tmitems.nim
@@ -51,7 +51,7 @@ block:
 
 block:
   var x = "foobar"
-  var y = cast[cstring](addr x[0])
+  var y = cast[cstring](addr(x[0]))
   for c in y.mitems:
     inc c
   echo x
@@ -64,7 +64,7 @@ block:
 
 block:
   var x = "foobar"
-  var y = cast[cstring](addr x[0])
+  var y = cast[cstring](addr(x[0]))
   for i, c in y.mpairs:
     inc c, i
   echo x

--- a/tools/fakedeps.nim
+++ b/tools/fakedeps.nim
@@ -5,7 +5,7 @@ proc fakeTimeDep() = echo(times.getDateStr())
 proc fakedeps() =
   var x = 0.4
   {.emit: "#if 0\n".}
-  fakeCppDep(addr x)
+  fakeCppDep(addr(x))
   {.emit: "#endif\n".}
 
   # this is not true:


### PR DESCRIPTION
Because addr now behaves like a regular proc, brackets are often required. For example in `ttypebar.nim`:
```nimrod
# bug #602

type
  TTest = object
  TTest2* = object
  TFoo = TTest | TTest2

proc f(src: ptr TFoo, dst: ptr TFoo) =
  echo("asd")

var x: TTest
f(addr x, addr x)
```
The last line now has to be:
```nimrod
f(addr(x), addr(x))
```