### PR TITLE
Fixed Tdirent definition for OS X and BSD.

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -94,7 +94,7 @@ type
   Tdirent* {.importc: "struct dirent",
              header: "<dirent.h>", final, pure.} = object ## dirent_t struct
     d_ino*: Tino  ## File serial number.
-    when defined(linux):
+    when defined(linux) or defined(macosx) or defined(bsd):
       d_off*: TOff  ## Not an offset. Value that ``telldir()`` would return.
       d_reclen*: cshort ## Length of this record. (not POSIX)
       d_type*: int8 ## Type of file; not supported by all filesystem types.


### PR DESCRIPTION
Entries d_type etc. were disabled on architectures other than Linux,
but also used for OS X and BSD in os.nim.