### PR TITLE
Change tcomputedgoto (fails compilation now)

### DIFF
--- a/tests/casestmt/tcomputedgoto.nim
+++ b/tests/casestmt/tcomputedgoto.nim
@@ -32,7 +32,7 @@ proc vm() =
   while true:
     {.computedGoto.}
     let instr = instructions[pc]
-    let ra = instr.succ # instr.regA
+    let ra = if instr < MyEnum.high: instr.succ else: instr
     case instr
     of enumA:
       echo "yeah A ", ra
@@ -43,5 +43,5 @@ proc vm() =
     of enumE:
       break
     inc(pc)
-  
+
 vm()


### PR DESCRIPTION
This test didn't work anymore because `succ` on enums is now checked for overflows. Still causes the problem in #2402 but should be fine after that's fixed.