### PR TITLE
Comp lib ropes

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -452,17 +452,16 @@ proc debug(n: PSym) =
   elif n.kind == skUnknown:
     msgWriteln("skUnknown")
   else:
-    #writeln(stdout, ropeToStr(symToYaml(n, 0, 1)))
+    #writeln(stdout, $symToYaml(n, 0, 1))
     msgWriteln("$1_$2: $3, $4, $5, $6" % [
-      n.name.s, $n.id, flagsToStr(n.flags).ropeToStr,
-      flagsToStr(n.loc.flags).ropeToStr, lineInfoToStr(n.info).ropeToStr,
-      $n.kind])
+      n.name.s, $n.id, $flagsToStr(n.flags), $flagsToStr(n.loc.flags),
+      $lineInfoToStr(n.info), $n.kind])
 
 proc debug(n: PType) =
-  msgWriteln(ropeToStr(debugType(n)))
+  msgWriteln($debugType(n))
 
 proc debug(n: PNode) =
-  msgWriteln(ropeToStr(debugTree(n, 0, 100)))
+  msgWriteln($debugTree(n, 0, 100))
 
 const
   EmptySeq = @[]

--- a/compiler/canonicalizer.nim
+++ b/compiler/canonicalizer.nim
@@ -243,24 +243,24 @@ proc encodeNode(w: PRodWriter, fInfo: TLineInfo, n: PNode,
       encodeNode(w, n.info, n.sons[i], result)
   add(result, ')')
 
-proc encodeLoc(w: PRodWriter, loc: TLoc, result: var string) = 
+proc encodeLoc(w: PRodWriter, loc: TLoc, result: var string) =
   var oldLen = result.len
   result.add('<')
   if loc.k != low(loc.k): encodeVInt(ord(loc.k), result)
-  if loc.s != low(loc.s): 
+  if loc.s != low(loc.s):
     add(result, '*')
     encodeVInt(ord(loc.s), result)
-  if loc.flags != {}: 
+  if loc.flags != {}:
     add(result, '$')
     encodeVInt(cast[int32](loc.flags), result)
   if loc.t != nil:
     add(result, '^')
     encodeVInt(cast[int32](loc.t.id), result)
     pushType(w, loc.t)
-  if loc.r != nil: 
+  if loc.r != nil:
     add(result, '!')
-    encodeStr(ropeToStr(loc.r), result)
-  if loc.a != 0: 
+    encodeStr($loc.r, result)
+  if loc.a != 0:
     add(result, '?')
     encodeVInt(loc.a, result)
   if oldLen + 1 == result.len:
@@ -317,7 +317,7 @@ proc encodeLib(w: PRodWriter, lib: PLib, info: TLineInfo, result: var string) =
   add(result, '|')
   encodeVInt(ord(lib.kind), result)
   add(result, '|')
-  encodeStr(ropeToStr(lib.name), result)
+  encodeStr($lib.name, result)
   add(result, '|')
   encodeNode(w, info, lib.path, result)
 

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -413,7 +413,7 @@ proc genInfixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   assert(typ.kind == tyProc)
   var length = sonsLen(ri)
   assert(sonsLen(typ) == sonsLen(typ.n))
-  # don't call 'ropeToStr' here for efficiency:
+  # don't call '$' here for efficiency:
   let pat = ri.sons[0].sym.loc.r.data
   internalAssert pat != nil
   if pat.contains({'#', '(', '@', '\''}):
@@ -462,7 +462,7 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
   var length = sonsLen(ri)
   assert(sonsLen(typ) == sonsLen(typ.n))
 
-  # don't call 'ropeToStr' here for efficiency:
+  # don't call '$' here for efficiency:
   let pat = ri.sons[0].sym.loc.r.data
   internalAssert pat != nil
   var start = 3

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1730,7 +1730,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       mParseBiggestFloat:
     var opr = e.sons[0].sym
     if lfNoDecl notin opr.loc.flags:
-      discard cgsym(p.module, opr.loc.r.ropeToStr)
+      discard cgsym(p.module, $opr.loc.r)
     genCall(p, e, d)
   of mReset: genReset(p, e)
   of mEcho: genEcho(p, e[1].skipConv)

--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -79,7 +79,7 @@ proc writeTypeCache(a: TIdTable, s: var string) =
       s.add(' ')
     encodeVInt(id, s)
     s.add(':')
-    encodeStr(PRope(value).ropeToStr, s)
+    encodeStr($PRope(value), s)
     inc i
   s.add('}')
 
@@ -280,11 +280,11 @@ proc readMergeSections(cfilename: string, m: var TMergeSections) =
 proc mergeRequired*(m: BModule): bool =
   for i in cfsHeaders..cfsProcs:
     if m.s[i] != nil:
-      #echo "not empty: ", i, " ", ropeToStr(m.s[i])
+      #echo "not empty: ", i, " ", m.s[i]
       return true
   for i in low(TCProcSection)..high(TCProcSection):
     if m.initProc.s(i) != nil:
-      #echo "not empty: ", i, " ", ropeToStr(m.initProc.s[i])
+      #echo "not empty: ", i, " ", m.initProc.s[i]
       return true
 
 proc mergeFiles*(cfilename: string, m: BModule) =

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -936,7 +936,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): PRope =
       if sym.kind in {skProc, skIterator, skClosureIterator, skMethod}:
         var a: TLoc
         initLocExpr(p, t.sons[i], a)
-        res.add(rdLoc(a).ropeToStr)
+        res.add($rdLoc(a))
       else:
         var r = sym.loc.r
         if r == nil:
@@ -944,7 +944,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): PRope =
           # it doesn't matter much:
           r = mangleName(sym)
           sym.loc.r = r       # but be consequent!
-        res.add(r.ropeToStr)
+        res.add($r)
     else: internalError(t.sons[i].info, "genAsmOrEmitStmt()")
 
   if isAsmStmt and hasGnuAsm in CC[cCompiler].props:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -77,13 +77,13 @@ proc mangleName(s: PSym): PRope =
       # These are not properly scoped now - we need to add blocks
       # around for loops in transf
       if keepOrigName:
-        result = s.name.s.mangle.newRope
+        result = s.name.s.mangle.toRope
       else:
-        app(result, newRope(mangle(s.name.s)))
+        app(result, toRope(mangle(s.name.s)))
         app(result, ~"_")
         app(result, toRope(s.id))
     else:
-      app(result, newRope(mangle(s.name.s)))
+      app(result, toRope(mangle(s.name.s)))
       app(result, ~"_")
       app(result, toRope(s.id))
     s.loc.r = result

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -120,7 +120,7 @@ proc ropecg(m: BModule, frmt: TFormatStr, args: varargs[PRope]): PRope =
       while frmt[i] in Digits:
         j = (j * 10) + ord(frmt[i]) - ord('0')
         inc(i)
-      app(result, cgsym(m, args[j-1].ropeToStr))
+      app(result, cgsym(m, $args[j-1]))
     var start = i
     while i < length:
       if frmt[i] != '$' and frmt[i] != '#': inc(i)
@@ -555,8 +555,7 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
       params.app(rdLoc(a))
       params.app(", ")
     let load = ropef("\t$1 = ($2) ($3$4));$n",
-        [tmp, getTypeDesc(m, sym.typ),
-        params, makeCString(ropeToStr(extname))])
+        [tmp, getTypeDesc(m, sym.typ), params, makeCString($extname)])
     var last = lastSon(n)
     if last.kind == nkHiddenStdConv: last = last.sons[1]
     internalAssert(last.kind == nkStrLit)
@@ -570,8 +569,7 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
   else:
     appcg(m, m.s[cfsDynLibInit],
         "\t$1 = ($2) #nimGetProcAddr($3, $4);$n",
-        [tmp, getTypeDesc(m, sym.typ),
-        lib.name, makeCString(ropeToStr(extname))])
+        [tmp, getTypeDesc(m, sym.typ), lib.name, makeCString($extname)])
   appf(m.s[cfsVars], "$2 $1;$n", [sym.loc.r, getTypeDesc(m, sym.loc.t)])
 
 proc varInDynamicLib(m: BModule, sym: PSym) =
@@ -584,8 +582,7 @@ proc varInDynamicLib(m: BModule, sym: PSym) =
   inc(m.labels, 2)
   appcg(m, m.s[cfsDynLibInit],
       "$1 = ($2*) #nimGetProcAddr($3, $4);$n",
-      [tmp, getTypeDesc(m, sym.typ),
-      lib.name, makeCString(ropeToStr(extname))])
+      [tmp, getTypeDesc(m, sym.typ), lib.name, makeCString($extname)])
   appf(m.s[cfsVars], "$2* $1;$n",
       [sym.loc.r, getTypeDesc(m, sym.loc.t)])
 
@@ -1255,7 +1252,7 @@ proc writeModule(m: BModule, pending: bool) =
     var code = genModule(m, cfile)
     when hasTinyCBackend:
       if gCmd == cmdRun:
-        tccgen.compileCCode(ropeToStr(code))
+        tccgen.compileCCode($code)
         return
 
     if shouldRecompile(code, cfile):

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -436,7 +436,7 @@ proc genJSONItem(d: PDoc, n, nameNode: PNode, k: TSymKind): JsonNode =
   if not isVisible(nameNode): return
   var
     name = getName(d, nameNode)
-    comm = genRecComment(d, n).ropeToStr()
+    comm = $genRecComment(d, n)
     r: TSrcGen
 
   initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments})

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -635,7 +635,7 @@ proc commandJSON*() =
   var d = newDocumentor(gProjectFull, options.gConfigVars)
   d.hasToc = true
   var json = generateJson(d, ast)
-  var content = newRope(pretty(json))
+  var content = toRope(pretty(json))
 
   if optStdout in gGlobalOptions:
     writeRope(stdout, content)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -874,7 +874,7 @@ proc genFieldAddr(p: PProc, n: PNode, r: var TCompRes) =
     if b.sons[1].kind != nkSym: internalError(b.sons[1].info, "genFieldAddr")
     var f = b.sons[1].sym
     if f.loc.r == nil: f.loc.r = mangleName(f)
-    r.res = makeJSString(ropeToStr(f.loc.r))
+    r.res = makeJSString($f.loc.r)
   internalAssert a.typ != etyBaseIndex
   r.address = a.res
   r.kind = resExpr

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -494,20 +494,16 @@ proc toCChar*(c: char): string =
   else: result = $(c)
 
 proc makeCString*(s: string): PRope =
-  # BUGFIX: We have to split long strings into many ropes. Otherwise
-  # this could trigger an internalError(). See the ropes module for
-  # further information.
   const
     MaxLineLength = 64
   result = nil
-  var res = "\""
+  var res = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
+  add(res, "\"")
   for i in countup(0, len(s) - 1):
     if (i + 1) mod MaxLineLength == 0:
       add(res, '\"')
       add(res, tnl)
-      app(result, toRope(res)) # reset:
-      setLen(res, 1)
-      res[0] = '\"'
+      add(res, '\"')
     add(res, toCChar(s[i]))
   add(res, '\"')
   app(result, toRope(res))
@@ -877,8 +873,6 @@ ropes.errorHandler = proc (err: TRopesError, msg: string, useWarning: bool) =
   case err
   of rInvalidFormatStr:
     internalError("ropes: invalid format string: " & msg)
-  of rTokenTooLong:
-    internalError("ropes: token too long: " & msg)
   of rCannotOpenFile:
     rawMessage(if useWarning: warnCannotOpenFile else: errCannotOpenFile, msg)
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -776,7 +776,7 @@ proc rawMessage*(msg: TMsgKind, arg: string) =
 
 proc writeSurroundingSrc(info: TLineInfo) =
   const indent = "  "
-  msgWriteln(indent & info.sourceLine.ropeToStr)
+  msgWriteln(indent & $info.sourceLine)
   msgWriteln(indent & spaces(info.col) & '^')
 
 proc formatMsg*(info: TLineInfo, msg: TMsgKind, arg: string): string =

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -105,7 +105,7 @@ proc validateExternCName(s: PSym, info: TLineInfo) =
   ## Valid identifiers are those alphanumeric including the underscore not
   ## starting with a number. If the check fails, a generic error will be
   ## displayed to the user.
-  let target = ropeToStr(s.loc.r)
+  let target = $s.loc.r
   if target.len < 1 or target[0] notin IdentStartChars or
       not target.allCharsInSet(IdentChars):
     localError(info, errGenerated, "invalid exported symbol")

--- a/compiler/rodwrite.nim
+++ b/compiler/rodwrite.nim
@@ -186,7 +186,7 @@ proc encodeLoc(w: PRodWriter, loc: TLoc, result: var string) =
     pushType(w, loc.t)
   if loc.r != nil: 
     add(result, '!')
-    encodeStr(ropeToStr(loc.r), result)
+    encodeStr($loc.r, result)
   if oldLen + 1 == result.len:
     # no data was necessary, so remove the '<' again:
     setLen(result, oldLen)
@@ -241,7 +241,7 @@ proc encodeLib(w: PRodWriter, lib: PLib, info: TLineInfo, result: var string) =
   add(result, '|')
   encodeVInt(ord(lib.kind), result)
   add(result, '|')
-  encodeStr(ropeToStr(lib.name), result)
+  encodeStr($lib.name, result)
   add(result, '|')
   encodeNode(w, info, lib.path, result)
 

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -103,7 +103,7 @@ proc len*(a: PRope): int =
   if a == nil: result = 0
   else: result = a.length
 
-proc newRope*(data: string = nil): PRope =
+proc newRope(data: string = nil): PRope =
   new(result)
   if data != nil:
     result.length = len(data)

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -275,7 +275,7 @@ proc `%`*(frmt: TFormatStr, args: openArray[Rope]): Rope =
         while true:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-          if (i >= length) or frmt[i] notin {'0'..'9'}: break
+          if frmt[i] notin {'0'..'9'}: break
         num = j
         if j > high(args) + 1:
           errorHandler(rInvalidFormatStr, $(j))

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -87,7 +87,6 @@ proc prepend*(a: var PRope, b: PRope)
 proc toRope*(s: string): PRope
 proc toRope*(i: BiggestInt): PRope
 proc writeRopeIfNotEqual*(r: PRope, filename: string): bool
-proc ropeToStr*(p: PRope): string
 proc ropef*(frmt: TFormatStr, args: varargs[PRope]): PRope
 proc appf*(c: var PRope, frmt: TFormatStr, args: varargs[PRope])
 proc ropeEqualsFile*(r: PRope, f: string): bool
@@ -180,7 +179,7 @@ proc newRecRopeToStr(result: var string, resultLen: var int, r: PRope) =
     inc(resultLen, it.length)
     assert(resultLen <= len(result))
 
-proc ropeToStr(p: PRope): string =
+proc `$`*(p: PRope): string =
   if p == nil:
     result = ""
   else:

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -284,11 +284,11 @@ proc `%`*(frmt: TFormatStr, args: openArray[Rope]): Rope =
       of '{':
         inc(i)
         var j = 0
-        while i < length and frmt[i] in {'0'..'9'}:
+        while frmt[i] in {'0'..'9'}:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
         num = j
-        if i < length and frmt[i] == '}': inc(i)
+        if frmt[i] == '}': inc(i)
         else: errorHandler(rInvalidFormatStr, $(frmt[i]))
 
         if j > high(args) + 1:

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -264,8 +264,22 @@ proc `%`*(frmt: TFormatStr, args: openArray[PRope]): PRope =
         while true:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-          if (i > length - 1) or frmt[i] notin {'0'..'9'}: break
+          if (i >= length) or frmt[i] notin {'0'..'9'}: break
         num = j
+        if j > high(args) + 1:
+          errorHandler(rInvalidFormatStr, $(j))
+        else:
+          add(result, args[j-1])
+      of '{':
+        inc(i)
+        var j = 0
+        while i < length and frmt[i] in {'0'..'9'}:
+          j = j * 10 + ord(frmt[i]) - ord('0')
+          inc(i)
+        num = j
+        if i < length and frmt[i] == '}': inc(i)
+        else: errorHandler(rInvalidFormatStr, $(frmt[i]))
+
         if j > high(args) + 1:
           errorHandler(rInvalidFormatStr, $(j))
         else:

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -76,11 +76,10 @@ type
     rCannotOpenFile
     rInvalidFormatStr
 
-  # TODO Compatibility names - update uses
-  TFormatStr* = FormatStr
-  PRope* = Rope
-  TRopeSeq* = RopeSeq
-  TRopesError* = RopesError
+{.deprecated: [TFormatStr: FormatStr].}
+{.deprecated: [PRope: Rope].}
+{.deprecated: [TRopeSeq: RopeSeq].}
+{.deprecated: [TRopesError: RopesError].}
 
 # implementation
 
@@ -154,9 +153,9 @@ proc rope*(f: BiggestFloat): Rope =
   result = rope($f)
 
 # TODO Old names - change invokations to rope
-proc toRope*(s: string): Rope =
+proc toRope*(s: string): Rope {.deprecated.} =
   result = rope(s)
-proc toRope*(i: BiggestInt): Rope =
+proc toRope*(i: BiggestInt): Rope {.deprecated.}  =
   result = rope(i)
 
 proc ropeSeqInsert(rs: var RopeSeq, r: Rope, at: Natural) =
@@ -215,19 +214,19 @@ proc `$`*(p: Rope): string =
     var resultLen = 0
     newRecRopeToStr(result, resultLen, p)
 
-# TODO Old names - change invokations to &
-proc con*(a, b: Rope): Rope = a & b
-proc con*(a: Rope, b: string): Rope = a & b
-proc con*(a: string, b: Rope): Rope = a & b
-proc con*(a: varargs[Rope]): Rope = `&`(a)
+# TODO Old names - change invokations to `&`
+proc con*(a, b: Rope): Rope {.deprecated.} = a & b
+proc con*(a: Rope, b: string): Rope {.deprecated.} = a & b
+proc con*(a: string, b: Rope): Rope {.deprecated.} = a & b
+proc con*(a: varargs[Rope]): Rope {.deprecated.} = `&`(a)
 
 proc ropeConcat*(a: varargs[Rope]): Rope =
   # not overloaded version of concat to speed-up `rfmt` a little bit
   for i in countup(0, high(a)): result = con(result, a[i])
 
 # TODO Old names - change invokations to add
-proc app*(a: var Rope, b: Rope) = add(a, b)
-proc app*(a: var Rope, b: string) = add(a, b)
+proc app*(a: var Rope, b: Rope) {.deprecated.} = add(a, b)
+proc app*(a: var Rope, b: string) {.deprecated.} = add(a, b)
 
 proc prepend*(a: var Rope, b: Rope) = a = b & a
 proc prepend*(a: var Rope, b: string) = a = b & a
@@ -316,9 +315,9 @@ proc addf*(c: var Rope, frmt: TFormatStr, args: openArray[Rope]) =
   add(c, frmt % args)
 
 # TODO Compatibility names
-proc ropef*(frmt: TFormatStr, args: varargs[Rope]): Rope =
+proc ropef*(frmt: TFormatStr, args: varargs[Rope]): Rope {.deprecated.} =
   result = frmt % args
-proc appf*(c: var Rope, frmt: TFormatStr, args: varargs[Rope]) =
+proc appf*(c: var Rope, frmt: TFormatStr, args: varargs[Rope]) {.deprecated.} =
   addf(c, frmt, args)
 
 when true:

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -86,7 +86,6 @@ proc app*(a: var PRope, b: string)
 proc prepend*(a: var PRope, b: PRope)
 proc toRope*(s: string): PRope
 proc toRope*(i: BiggestInt): PRope
-proc ropeLen*(a: PRope): int
 proc writeRopeIfNotEqual*(r: PRope, filename: string): bool
 proc ropeToStr*(p: PRope): string
 proc ropef*(frmt: TFormatStr, args: varargs[PRope]): PRope
@@ -100,7 +99,7 @@ proc ropeInvariant*(r: PRope): bool
 var errorHandler*: proc(err: TRopesError, msg: string, useWarning = false)
   # avoid dependency on msgs.nim
 
-proc ropeLen(a: PRope): int =
+proc len*(a: PRope): int =
   if a == nil: result = 0
   else: result = a.length
 

--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -315,15 +315,15 @@ proc `%`*(frmt: string, args: openArray[Rope]): Rope {.
         while true:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-          if (i >= length) or frmt[i] notin {'0'..'9'}: break
+          if frmt[i] notin {'0'..'9'}: break
         add(result, args[j-1])
       of '{':
         inc(i)
         var j = 0
-        while i < length and frmt[i] in {'0'..'9'}:
+        while frmt[i] in {'0'..'9'}:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-        if i < length and frmt[i] == '}': inc(i)
+        if frmt[i] == '}': inc(i)
         else: raise newException(ValueError, "invalid format string")
 
         add(result, args[j-1])

--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -290,8 +290,8 @@ when false:
         else: break 
       if i - 1 >= start: 
         add(result, substr(frmt, start, i-1))
-  
-proc `%`*(frmt: string, args: openArray[Rope]): Rope {. 
+
+proc `%`*(frmt: string, args: openArray[Rope]): Rope {.
   rtl, extern: "nroFormat".} =
   ## `%` substitution operator for ropes. Does not support the ``$identifier``
   ## nor ``${identifier}`` notations.
@@ -299,39 +299,40 @@ proc `%`*(frmt: string, args: openArray[Rope]): Rope {.
   var length = len(frmt)
   result = nil
   var num = 0
-  while i < length: 
-    if frmt[i] == '$': 
+  while i < length:
+    if frmt[i] == '$':
       inc(i)
       case frmt[i]
-      of '$': 
+      of '$':
         add(result, "$")
         inc(i)
-      of '#': 
+      of '#':
         inc(i)
         add(result, args[num])
         inc(num)
-      of '0'..'9': 
+      of '0'..'9':
         var j = 0
-        while true: 
+        while true:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-          if frmt[i] notin {'0'..'9'}: break 
+          if (i >= length) or frmt[i] notin {'0'..'9'}: break
         add(result, args[j-1])
       of '{':
         inc(i)
         var j = 0
-        while frmt[i] in {'0'..'9'}:
+        while i < length and frmt[i] in {'0'..'9'}:
           j = j * 10 + ord(frmt[i]) - ord('0')
           inc(i)
-        if frmt[i] == '}': inc(i)
+        if i < length and frmt[i] == '}': inc(i)
         else: raise newException(ValueError, "invalid format string")
+
         add(result, args[j-1])
       else: raise newException(ValueError, "invalid format string")
     var start = i
-    while i < length: 
+    while i < length:
       if frmt[i] != '$': inc(i)
-      else: break 
-    if i - 1 >= start: 
+      else: break
+    if i - 1 >= start:
       add(result, substr(frmt, start, i - 1))
 
 proc addf*(c: var Rope, frmt: string, args: openArray[Rope]) {.


### PR DESCRIPTION
Make compiler ropes API more similar to library ropes, using library API as model, and fix a few small rope bugs here and there..

I kept away from any big rename commits, opting instead to keep the old API around, allowing a gradual change. Can easily be followed up with a separate cleanup run.