### PR TITLE
Fixed doc generation on mac.

### DIFF
--- a/lib/pure/rawsockets.nim
+++ b/lib/pure/rawsockets.nim
@@ -429,7 +429,7 @@ proc selectWrite*(writefds: var seq[SocketHandle],
   pruneSocketSet(writefds, (wr))
 
 # We ignore signal SIGPIPE on Darwin
-when defined(macosx):
+when defined(macosx) and not defined(nimdoc):
   signal(SIGPIPE, SIG_IGN)
 
 when defined(Windows):


### PR DESCRIPTION
nimdoc follows windows conditional branches and thus doesn't import posix, so ```signal``` is undefined symbol.