### PR TITLE
Separate nimcache files for each binary in common directory

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1733,7 +1733,7 @@ proc myClose(b: PPassContext, n: PNode): PNode =
         if options.outFile.isAbsolute: options.outFile
         else: getCurrentDir() / options.outFile
       else:
-       changeFileExt(completeCFilePath(m.module.filename), "js")
+       changeFileExt(completeCFilePath(m.module.filename, prependModule=false), "js")
     discard writeRopeIfNotEqual(con(genHeader(), code), outfile)
 
 proc myOpenCached(s: PSym, rd: PRodReader): PPassContext =

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -69,7 +69,7 @@ proc handleCmdLine() =
             ex = options.outFile.prependCurDir.quoteShell
           else:
             ex = quoteShell(
-              completeCFilePath(changeFileExt(gProjectFull, "js").prependCurDir))
+              completeCFilePath(changeFileExt(gProjectFull, "js").prependCurDir, prependModule=false))
           execExternalProgram(findNodeJs() & " " & ex & ' ' & commands.arguments)
         else:
           var binPath: string

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -395,7 +395,7 @@ proc processCompile(c: PContext, n: PNode) =
   if found == "": found = s
   var trunc = changeFileExt(found, "")
   extccomp.addExternalFileToCompile(found)
-  extccomp.addFileToLink(completeCFilePath(trunc, false))
+  extccomp.addFileToLink(completeCFilePath(trunc, false, false))
 
 proc processCommonLink(c: PContext, n: PNode, feature: TLinkFeature) =
   var f = expectStrLit(c, n)
@@ -405,7 +405,7 @@ proc processCommonLink(c: PContext, n: PNode, feature: TLinkFeature) =
   case feature
   of linkNormal: extccomp.addFileToLink(found)
   of linkSys:
-    extccomp.addFileToLink(libpath / completeCFilePath(found, false))
+    extccomp.addFileToLink(libpath / completeCFilePath(found, false, false))
   else: internalError(n.info, "processCommonLink")
 
 proc pragmaBreakpoint(c: PContext, n: PNode) =

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -139,7 +139,7 @@ proc cmpMsgs(r: var TResults, expected, given: TSpec, test: TTest) =
 proc generatedFile(path, name: string, target: TTarget): string =
   let ext = targetToExt[target]
   result = path / "nimcache" /
-    (if target == targetJS: path.splitPath.tail & "_" else: "compiler_") &
+    (if target == targetJS: path.splitPath.tail & "_" else: name.changeFileExt("") & "_compiler_") &
     name.changeFileExt(ext)
 
 proc codegenCheck(test: TTest, check: string, given: var TSpec) =


### PR DESCRIPTION
This speeds up recompilation by improving reusability of the nimcache files.

I have a few projects that have multiple binaries in a single directory (https://github.com/kanaka/mal/tree/master/nim, https://github.com/def-/nim-unsorted). Recompilation is slow even if nothing changed because each binary overwrites each others' nimcache files. First I tried fixing this with `--deadcodeelim:off`, but ran into https://github.com/Araq/Nim/issues/2453.

I'm aware that you could use a separate nimcache for each binary, but that's clunky and you can't reuse external C files. mal/nim uses PCRE and recompiling it for all 10 binaries takes quite some time. Since C has no generics, we don't run into the problems with #2453 and can safely share external C files and their obj files.

The speedup for recompilation with hot nimcache in mal/nim is from 33 seconds to 5 seconds on my machine.

The downside is that the nimcache is bigger if you have multiple binaries in a single directory. Edit: It grows a lot, for Nim's tests from 129 MB to 483 MB. Maybe this is not such a good idea after all.

I tested bootstrapping and the tests and they still work.