### PR TITLE
DOM types renamed.

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -38,8 +38,9 @@ type
 
     addEventListener*: proc(ev: cstring, cb: proc(ev: ref TEvent), useCapture: bool = false) {.nimcall.}
 
-  TWindow* {.importc.} = object of TEventHandlers
-    document*: ref TDocument
+  Window* = ref WindowObj
+  WindowObj {.importc.} = object of TEventHandlers
+    document*: Document
     event*: ref TEvent
     history*: ref THistory
     location*: ref TLocation
@@ -67,7 +68,7 @@ type
     confirm*: proc (msg: cstring): bool {.nimcall.}
     disableExternalCapture*: proc () {.nimcall.}
     enableExternalCapture*: proc () {.nimcall.}
-    find*: proc (text: cstring, caseSensitive = false, 
+    find*: proc (text: cstring, caseSensitive = false,
                  backwards = false) {.nimcall.}
     focus*: proc () {.nimcall.}
     forward*: proc () {.nimcall.}
@@ -76,7 +77,7 @@ type
     moveBy*: proc (x, y: int) {.nimcall.}
     moveTo*: proc (x, y: int) {.nimcall.}
     open*: proc (uri, windowname: cstring,
-                 properties: cstring = nil): ref TWindow {.nimcall.}
+                 properties: cstring = nil): Window {.nimcall.}
     print*: proc () {.nimcall.}
     prompt*: proc (text, default: cstring): cstring {.nimcall.}
     releaseEvents*: proc (eventMask: int) {.nimcall.}
@@ -90,7 +91,8 @@ type
     stop*: proc () {.nimcall.}
     frames*: seq[TFrame]
 
-  TFrame* {.importc.} = object of TWindow
+  Frame* = ref FrameObj
+  FrameObj {.importc.} = object of WindowObj
 
   ClassList* {.importc.} = object of RootObj
     add*: proc (class: cstring) {.nimcall.}
@@ -111,40 +113,43 @@ type
     DocumentTypeNode,
     DocumentFragmentNode,
     NotationNode
-  TNode* {.importc.} = object of TEventHandlers
-    attributes*: seq[ref TNode]
-    childNodes*: seq[ref TNode]
-    children*: seq[ref TNode]
+
+  Node* = ref NodeObj
+  NodeObj {.importc.} = object of TEventHandlers
+    attributes*: seq[Node]
+    childNodes*: seq[Node]
+    children*: seq[Node]
     data*: cstring
-    firstChild*: ref TNode
-    lastChild*: ref TNode
-    nextSibling*: ref TNode
+    firstChild*: Node
+    lastChild*: Node
+    nextSibling*: Node
     nodeName*: cstring
     nodeType*: TNodeType
     nodeValue*: cstring
-    parentNode*: ref TNode
-    previousSibling*: ref TNode
-    appendChild*: proc (child: ref TNode) {.nimcall.}
+    parentNode*: Node
+    previousSibling*: Node
+    appendChild*: proc (child: Node) {.nimcall.}
     appendData*: proc (data: cstring) {.nimcall.}
-    cloneNode*: proc (copyContent: bool): ref TNode {.nimcall.}
+    cloneNode*: proc (copyContent: bool): Node {.nimcall.}
     deleteData*: proc (start, len: int) {.nimcall.}
     getAttribute*: proc (attr: cstring): cstring {.nimcall.}
-    getAttributeNode*: proc (attr: cstring): ref TNode {.nimcall.}
+    getAttributeNode*: proc (attr: cstring): Node {.nimcall.}
     hasChildNodes*: proc (): bool {.nimcall.}
     innerHTML*: cstring
-    insertBefore*: proc (newNode, before: ref TNode) {.nimcall.}
+    insertBefore*: proc (newNode, before: Node) {.nimcall.}
     insertData*: proc (position: int, data: cstring) {.nimcall.}
     removeAttribute*: proc (attr: cstring) {.nimcall.}
-    removeAttributeNode*: proc (attr: ref TNode) {.nimcall.}
-    removeChild*: proc (child: ref TNode) {.nimcall.}
-    replaceChild*: proc (newNode, oldNode: ref TNode) {.nimcall.}
+    removeAttributeNode*: proc (attr: Node) {.nimcall.}
+    removeChild*: proc (child: Node) {.nimcall.}
+    replaceChild*: proc (newNode, oldNode: Node) {.nimcall.}
     replaceData*: proc (start, len: int, text: cstring) {.nimcall.}
     scrollIntoView*: proc () {.nimcall.}
     setAttribute*: proc (name, value: cstring) {.nimcall.}
-    setAttributeNode*: proc (attr: ref TNode) {.nimcall.}
+    setAttributeNode*: proc (attr: Node) {.nimcall.}
     style*: ref TStyle
 
-  TDocument* {.importc.} = object of TNode
+  Document* = ref DocumentObj
+  DocumentObj {.importc.} = object of NodeObj
     alinkColor*: cstring
     bgColor*: cstring
     charset*: cstring
@@ -158,13 +163,13 @@ type
     URL*: cstring
     vlinkColor*: cstring
     captureEvents*: proc (eventMask: int) {.nimcall.}
-    createAttribute*: proc (identifier: cstring): ref TNode {.nimcall.}
-    createElement*: proc (identifier: cstring): ref TNode {.nimcall.}
-    createTextNode*: proc (identifier: cstring): ref TNode {.nimcall.}
-    getElementById*: proc (id: cstring): ref TElement {.nimcall.}
-    getElementsByName*: proc (name: cstring): seq[ref TElement] {.nimcall.}
-    getElementsByTagName*: proc (name: cstring): seq[ref TElement] {.nimcall.}
-    getElementsByClassName*: proc (name: cstring): seq[ref TElement] {.nimcall.}
+    createAttribute*: proc (identifier: cstring): Node {.nimcall.}
+    createElement*: proc (identifier: cstring): Element {.nimcall.}
+    createTextNode*: proc (identifier: cstring): Node {.nimcall.}
+    getElementById*: proc (id: cstring): Element {.nimcall.}
+    getElementsByName*: proc (name: cstring): seq[Element] {.nimcall.}
+    getElementsByTagName*: proc (name: cstring): seq[Element] {.nimcall.}
+    getElementsByClassName*: proc (name: cstring): seq[Element] {.nimcall.}
     getSelection*: proc (): cstring {.nimcall.}
     handleEvent*: proc (event: ref TEvent) {.nimcall.}
     open*: proc () {.nimcall.}
@@ -172,20 +177,21 @@ type
     routeEvent*: proc (event: ref TEvent) {.nimcall.}
     write*: proc (text: cstring) {.nimcall.}
     writeln*: proc (text: cstring) {.nimcall.}
-    anchors*: seq[ref TAnchor]
-    forms*: seq[ref TForm]
-    images*: seq[ref TImage]
+    anchors*: seq[AnchorElement]
+    forms*: seq[FormElement]
+    images*: seq[ImageElement]
     applets*: seq[ref TApplet]
-    embeds*: seq[ref TEmbed]
-    links*: seq[ref TLink]
+    embeds*: seq[EmbedElement]
+    links*: seq[LinkElement]
 
-  TElement* {.importc.} = object of TNode
+  Element* = ref ElementObj
+  ElementObj {.importc.} = object of NodeObj
     classList*: ref Classlist
     checked*: bool
     defaultChecked*: bool
     defaultValue*: cstring
     disabled*: bool
-    form*: ref TForm
+    form*: FormElement
     name*: cstring
     readOnly*: bool
     blur*: proc () {.nimcall.}
@@ -193,17 +199,19 @@ type
     focus*: proc () {.nimcall.}
     handleEvent*: proc (event: ref TEvent) {.nimcall.}
     select*: proc () {.nimcall.}
-    options*: seq[ref TOption]
-    getElementsByTagName*: proc (name: cstring): seq[ref TNode] {.nimcall.}
-    getElementsByClassName*: proc (name: cstring): seq[ref TNode] {.nimcall.}
+    options*: seq[OptionElement]
+    getElementsByTagName*: proc (name: cstring): seq[Element] {.nimcall.}
+    getElementsByClassName*: proc (name: cstring): seq[Element] {.nimcall.}
 
-  TLink* {.importc.} = object of TElement
+  LinkElement* = ref LinkObj
+  LinkObj {.importc.} = object of ElementObj
     target*: cstring
     text*: cstring
     x*: int
     y*: int
 
-  TEmbed* {.importc.} = object of TElement
+  EmbedElement* = ref EmbedObj
+  EmbedObj {.importc.} = object of ElementObj
     height*: int
     hspace*: int
     src*: cstring
@@ -213,30 +221,33 @@ type
     play*: proc () {.nimcall.}
     stop*: proc () {.nimcall.}
 
-  TAnchor* {.importc.} = object of RootObj
-    name*: cstring
+  AnchorElement* = ref AnchorObj
+  AnchorObj {.importc.} = object of ElementObj
     text*: cstring
     x*, y*: int
 
   TApplet* {.importc.} = object of RootObj
 
-  TOption* {.importc.} = object of TElement
+  OptionElement* = ref OptionObj
+  OptionObj {.importc.} = object of ElementObj
     defaultSelected*: bool
     selected*: bool
     selectedIndex*: int
     text*: cstring
     value*: cstring
 
-  TForm* {.importc.} = object of TElement
+  FormElement* = ref FormObj
+  FormObj {.importc.} = object of ElementObj
     action*: cstring
     encoding*: cstring
     `method`*: cstring
     target*: cstring
     reset*: proc () {.nimcall.}
     submit*: proc () {.nimcall.}
-    elements*: seq[ref TElement]
+    elements*: seq[Element]
 
-  TImage* {.importc.} = object of TElement
+  ImageElement* = ref ImageObj
+  ImageObj {.importc.} = object of ElementObj
     border*: int
     complete*: bool
     height*: int
@@ -342,7 +353,7 @@ type
     setAttribute*: proc (attr, value: cstring, caseSensitive=false) {.nimcall.}
 
   TEvent* {.importc.} = object of RootObj
-    target*: ref TNode
+    target*: Node
     altKey*, ctrlKey*, shiftKey*: bool
     button*: int
     clientX*, clientY*: int
@@ -440,8 +451,8 @@ type
   TInterval* {.importc.} = object of RootObj
 
 var
-  window* {.importc, nodecl.}: ref TWindow
-  document* {.importc, nodecl.}: ref TDocument
+  window* {.importc, nodecl.}: Window
+  document* {.importc, nodecl.}: Document
   navigator* {.importc, nodecl.}: ref TNavigator
   screen* {.importc, nodecl.}: ref TScreen
 
@@ -458,3 +469,17 @@ proc isNaN*(x: BiggestFloat): bool {.importc, nodecl.}
 proc parseFloat*(s: cstring): BiggestFloat {.importc, nodecl.}
 proc parseInt*(s: cstring): int {.importc, nodecl.}
 proc parseInt*(s: cstring, radix: int):int {.importc, nodecl.}
+
+
+type
+  TWindow* {.deprecated.} = WindowObj
+  TFrame* {.deprecated.} = FrameObj
+  TNode* {.deprecated.} = NodeObj
+  TDocument* {.deprecated.} = DocumentObj
+  TElement* {.deprecated.} = ElementObj
+  TLink* {.deprecated.} = LinkObj
+  TEmbed* {.deprecated.} = EmbedObj
+  TAnchor* {.deprecated.} = AnchorObj
+  TOption* {.deprecated.} = OptionObj
+  TForm* {.deprecated.} = FormObj
+  TImage* {.deprecated.} = ImageObj


### PR DESCRIPTION
The main idea of the PR is to deprecate old T* names as well as their value-type semantics. Introduced new types with reference type semantics. Also some minor fixes: element-related methods return Elements, not Nodes. This PR changes the names of classes that belong to DOM-Node hierarchy only. Guess I'll do a separate PR for the rest.