### PR TITLE
Apply strongSpaces to keyword operators too. Fix #1894.

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -215,25 +215,25 @@ proc getPrecedence(tok: TToken, strongSpaces: bool): int =
     if L > 1 and tok.ident.s[L-1] == '>': return considerStrongSpaces(1)
 
     template considerAsgn(value: expr) =
-      result = if tok.ident.s[L-1] == '=': 1 else: considerStrongSpaces(value)
+      result = if tok.ident.s[L-1] == '=': 1 else: value
 
     case relevantChar
     of '$', '^': considerAsgn(10)
     of '*', '%', '/', '\\': considerAsgn(9)
-    of '~': result = considerStrongSpaces(8)
+    of '~': result = 8
     of '+', '-', '|': considerAsgn(8)
     of '&': considerAsgn(7)
-    of '=', '<', '>', '!': result = considerStrongSpaces(5)
+    of '=', '<', '>', '!': result = 5
     of '.': considerAsgn(6)
-    of '?': result = considerStrongSpaces(2)
+    of '?': result = 2
     else: considerAsgn(2)
-  of tkDiv, tkMod, tkShl, tkShr: result = considerStrongSpaces(9)
-  of tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf, tkAs:
-    result = considerStrongSpaces(5)
-  of tkDotDot: result = considerStrongSpaces(6)
-  of tkAnd: result = considerStrongSpaces(4)
-  of tkOr, tkXor, tkPtr, tkRef: result = considerStrongSpaces(3)
-  else: result = -10
+  of tkDiv, tkMod, tkShl, tkShr: result = 9
+  of tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf, tkAs: result = 5
+  of tkDotDot: result = 6
+  of tkAnd: result = 4
+  of tkOr, tkXor, tkPtr, tkRef: result = 3
+  else: return -10
+  result = considerStrongSpaces(result)
 
 proc isOperator(tok: TToken): bool =
   ## Determines if the given token is an operator type token.

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -227,11 +227,12 @@ proc getPrecedence(tok: TToken, strongSpaces: bool): int =
     of '.': considerAsgn(6)
     of '?': result = considerStrongSpaces(2)
     else: considerAsgn(2)
-  of tkDiv, tkMod, tkShl, tkShr: result = 9
-  of tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf, tkAs: result = 5
+  of tkDiv, tkMod, tkShl, tkShr: result = considerStrongSpaces(9)
+  of tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf, tkAs:
+    result = considerStrongSpaces(5)
   of tkDotDot: result = considerStrongSpaces(6)
-  of tkAnd: result = 4
-  of tkOr, tkXor, tkPtr, tkRef: result = 3
+  of tkAnd: result = considerStrongSpaces(4)
+  of tkOr, tkXor, tkPtr, tkRef: result = considerStrongSpaces(3)
   else: result = -10
 
 proc isOperator(tok: TToken): bool =

--- a/tests/parser/tstrongspaces.nim
+++ b/tests/parser/tstrongspaces.nim
@@ -2,6 +2,12 @@
 
 discard """
   output: '''35
+true
+true
+4
+true
+1
+false
 77
 (Field0: 1, Field1: 2, Field2: 2)
 ha
@@ -14,6 +20,17 @@ all args
 
 echo 2+5 * 5
 
+# Keyword operators
+echo 1 + 16 shl 1 == 1 + (16 shl 1)
+echo 2 and 1  in  {0, 30}
+echo 2+2 * 2 shr 1
+echo false  or  2 and 1  in  {0, 30}
+
+proc `^`(a, b: int): int = a + b div 2
+echo 19 mod 16 ^ 4  +  2 and 1
+echo 18 mod 16 ^ 4 > 0
+
+# echo $foo gotcha
 let foo = 77
 echo $foo
 
@@ -27,7 +44,7 @@ when true:
   let b = 66
   let c = 90
   let bar = 8000
-  if foo+4 * 4 == 8 and b&c | 9  ++
+  if foo+4 * 4 == 8  and  b&c | 9  ++
       bar:
     echo "ho"
   else:


### PR DESCRIPTION
When #!strongSpaces is on, every operator affected by it gains priority higher than any operator not affected by it. This includes comparison operators, addition, etc. Hence the bug #1894. The way to fix it is to apply it to all operators.

It seems that counting spaces for keywords operators don't break anything in the parser. Of course, they can't have 0 spaces between their operands, but at least their precedence will work accordingly to their 1+ spaces.

I had to change one of the tests to compile, as the strongSpaces rule was extended to `and` too. I compiled some other unrelated things (including the compiler itself) and nothing seems broken.

