### PR TITLE
Fixes matching error #2418

### DIFF
--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -373,23 +373,26 @@ iterator split*(s: string, sep: Regex): string =
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##   ""
   ##   "this"
   ##   "is"
   ##   "an"
   ##   "example"
+  ##   ""
   ##
   var
-    first = 0
-    last = 0
+    first = -1
+    last = -1
   while last < len(s):
     var x = matchLen(s, sep, last)
     if x > 0: inc(last, x)
     first = last
+    if x == 0: inc(last)
     while last < len(s):
-      inc(last)
       x = matchLen(s, sep, last)
-      if x > 0: break
-    if first < last:
+      if x >= 0: break
+      inc(last)
+    if first <= last:
       yield substr(s, first, last-1)
 
 proc split*(s: string, sep: Regex): seq[string] =

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -474,7 +474,12 @@ when isMainModule:
   var accum: seq[string] = @[]
   for word in split("00232this02939is39an22example111", re"\d+"):
     accum.add(word)
-  assert(accum == @["this", "is", "an", "example"])
+  assert(accum == @["", "this", "is", "an", "example", ""])
+
+  accum = @[]
+  for word in split("AAA :   : BBB", re"\s*:\s*"):
+    accum.add(word)
+  assert(accum == @["AAA", "", "BBB"])
 
   for x in findAll("abcdef", re"^{.}", 3):
     assert x == "d"

--- a/web/news.txt
+++ b/web/news.txt
@@ -73,7 +73,11 @@ News
     for ``expr`` and ``stmt``. The new names capture the semantics much better
     and most likely  ``expr`` and ``stmt`` will be deprecated in favor of the
     new names.
-
+  - The ``split`` method in module ``re`` has changed. It now handles the case
+    of matches having a length of 0, and empty strings being yielded from the
+    iterator. A notable change might be that a pattern being matched at the
+    beginning and end of a string, will result in an empty string being produced
+    at the start and the end of the iterator.
 
   Language Additions
   ------------------


### PR DESCRIPTION
Fixes the split iterator, the main problem was with the incrementation
of 'last'. Last was first incremented to the index of the first
character after the match, but was then incremented again at the
beginning of the while loop. This caused a problem if that character
after the first match, also matched the regular expression. Fixes #2418 