### PR TITLE
Fixes #1986 when calling sameConstant on uint

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -368,7 +368,7 @@ proc sameConstant*(a, b: PNode): bool =
     case a.kind
     of nkSym: result = a.sym == b.sym
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkInt64Lit: result = a.intVal == b.intVal
+    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkType, nkNilLit: result = a.typ == b.typ

--- a/tests/tuples/tuint_tuple.nim
+++ b/tests/tuples/tuint_tuple.nim
@@ -1,0 +1,10 @@
+# bug #1986 found by gdmoore
+
+proc test(): int64 =
+  return 0xdeadbeef.int64
+
+const items = [
+  (var1: test(), var2: 100'u32),
+  (var1: test(), var2: 192'u32)
+]
+


### PR DESCRIPTION
The problem was saveConstant only checked the range
`nkCharLit..nkInt64Lit`, but not up to UInt. This lead to the sonsLen
method being called, where sons was never declared.

This commit changes it to `nkCharLit..nkUint64Lit`, to match the case
statements in the type definition of TNode, in ast.nim.