### PR TITLE
Added peeking procedures to streams

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -471,3 +471,13 @@ else:
       var handle = open(filename, flags)
       if handle < 0: raise newEOS("posix.open() call failed")
     result = newFileHandleStream(handle)
+
+when defined(testing):
+  var ss = newStringStream("The quick brown fox jumped over the lazy dog.\nThe lazy dog ran")
+  assert(ss.getPosition == 0)
+  assert(ss.peekStr(5) == "The q")
+  assert(ss.getPosition == 0) # haven't moved
+  assert(ss.readStr(5) == "The q")
+  assert(ss.getPosition == 5) # did move
+  assert(ss.peekLine() == "uick brown fox jumped over the lazy dog.")
+  assert(ss.getPosition == 5) # haven't moved

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -346,8 +346,8 @@ when not defined(js):
   
   proc fsPeekData(s: Stream, buffer: pointer, bufLen: int): int =
     let pos = fsGetPosition(s)
+    defer: fsSetPosition(s, pos)
     result = readBuffer(FileStream(s).f, buffer, bufLen)
-    fsSetPosition(s, pos)
 
   proc fsWriteData(s: Stream, buffer: pointer, bufLen: int) =
     if writeBuffer(FileStream(s).f, buffer, bufLen) != bufLen:

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -240,22 +240,9 @@ proc peekLine*(s: Stream, line: var TaintedString): bool =
   ## ``CRLF``. The newline character(s) are not part of the returned string.
   ## Returns ``false`` if the end of the file has been reached, ``true``
   ## otherwise. If ``false`` is returned `line` contains no new data.
-  line.string.setLen(0)
   let pos = getPosition(s)
-  while true:
-    var c = readChar(s)
-    if c == '\c': 
-      c = readChar(s)
-      break
-    elif c == '\L': break
-    elif c == '\0':
-      if line.len > 0: break
-      else: 
-        setPosition(s, pos)
-        return false
-    line.string.add(c)
-  setPosition(s, pos)
-  result = true
+  defer: setPosition(s, pos)
+  readLine(s, line)
 
 proc readLine*(s: Stream): TaintedString =
   ## Reads a line from a stream `s`. Note: This is not very efficient. Raises 
@@ -274,19 +261,9 @@ proc readLine*(s: Stream): TaintedString =
 proc peekLine*(s: Stream): TaintedString =
   ## Peeks a line from a stream `s`. Note: This is not very efficient. Raises 
   ## `EIO` if an error occurred.
-  result = TaintedString""
   let pos = getPosition(s)
-  while true:
-    var c = readChar(s)
-    if c == '\c': 
-      c = readChar(s)
-      setPosition(s, pos)
-      break
-    if c == '\L' or c == '\0':
-      setPosition(s, pos)
-      break
-    else:
-      result.string.add(c)
+  defer: setPosition(s, pos)
+  readLine(s)
 
 type
   StringStream* = ref StringStreamObj ## a stream that encapsulates a string


### PR DESCRIPTION
Peeking (reading without changing stream position) procs implemented. That is:

```nim
var ss = newStringStream("The quick brown fox jumped over the lazy dog.\nThe lazy dog ran")
echo ss.getPosition
echo ss.peekStr(5)
echo ss.getPosition
echo ss.readStr(5)
echo ss.getPosition
echo ss.peekLine()
echo ss.getPosition
```

produces
```
0
The q
0
The q
5
uick brown fox jumped over the lazy dog.
5
```