### PR TITLE
Add additional information to mapType internalError.

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -144,7 +144,9 @@ proc mapType(typ: PType): TCTypeKind =
   of tyCString: result = ctCString
   of tyInt..tyUInt64:
     result = TCTypeKind(ord(typ.kind) - ord(tyInt) + ord(ctInt))
-  else: internalError("mapType")
+  else:
+    internalError("mapType: could not map 'typ:" & $typ.kind &
+      "' to a TCTypeKind")
 
 proc mapReturnType(typ: PType): TCTypeKind =
   if skipTypes(typ, typedescInst).kind == tyArray: result = ctPtr


### PR DESCRIPTION
I wrote this bad program:

    # Crashes compiler
    type
      O = object
        i: int

    var
      o: O

    o = cast[O](nil)

And this causes the compiler to crash with very little information:

    Error: internal error: mapType

This adds additional information to the internal error and now it outputs:

    Error: internal error: mapType: could not map 'typ:tyNil' to a TCTypeKind

I suggest that mapType should probably return a result for tyNil and then
the compiler should probably produce a better error message.

But in the meantime adding more information can be helpful.
