### PR TITLE
Removed -mwindows option from clang invocation.

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -95,6 +95,7 @@ compiler llvmGcc:
   result.compilerExe = "llvm-gcc"
   result.cppCompiler = "llvm-g++"
   result.buildLib = "llvm-ar rcs $libfile $objfiles"
+  result.buildGui = ""
 
 # Clang (LLVM) C/C++ Compiler
 compiler clang:


### PR DESCRIPTION
I could not find anywhere that clang supports ``-mwindows`` option, unfortunately I don't have windows to test it. But since clang is not stable on windows anyway, I guess it could be ignored for now.

Fixes #2576