### PR TITLE
Add procs for VirtualAllocEx and VirtualFreeEx in windows.nim

### DIFF
--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18515,8 +18515,12 @@ proc GetProcAddress*(hModule: HINST, lpProcName: LPCSTR): FARPROC{.stdcall,
 proc GetVersion*(): DWORD{.stdcall, dynlib: "kernel32", importc: "GetVersion".}
 proc GlobalAlloc*(uFlags: int32, dwBytes: SIZE_T): HGLOBAL{.stdcall,
     dynlib: "kernel32", importc: "GlobalAlloc".}
+proc GlobalAlloc*(uFlags: int32, dwBytes: DWORD): HGLOBAL{.stdcall,
+    dynlib: "kernel32", importc: "GlobalAlloc", deprecated.}
 proc GlobalReAlloc*(hMem: HGLOBAL, dwBytes: SIZE_T, uFlags: int32): HGLOBAL{.
     stdcall, dynlib: "kernel32", importc: "GlobalReAlloc".}
+proc GlobalReAlloc*(hMem: HGLOBAL, dwBytes: DWORD, uFlags: int32): HGLOBAL{.
+    stdcall, dynlib: "kernel32", importc: "GlobalReAlloc", deprecated.}
 proc GlobalSize*(hMem: HGLOBAL): SIZE_T{.stdcall, dynlib: "kernel32",
                                         importc: "GlobalSize".}
 proc GlobalFlags*(hMem: HGLOBAL): WINUINT{.stdcall, dynlib: "kernel32",
@@ -18543,8 +18547,12 @@ proc GlobalMemoryStatus*(lpBuffer: LPMEMORYSTATUS){.stdcall, dynlib: "kernel32",
     importc: "GlobalMemoryStatus".}
 proc LocalAlloc*(uFlags: WINUINT, uBytes: SIZE_T): HLOCAL{.stdcall,
     dynlib: "kernel32", importc: "LocalAlloc".}
+proc LocalAlloc*(uFlags: WINUINT, uBytes: DWORD): HLOCAL{.stdcall,
+    dynlib: "kernel32", importc: "LocalAlloc", deprecated.}
 proc LocalReAlloc*(hMem: HLOCAL, uBytes: SIZE_T, uFlags: WINUINT): HLOCAL{.stdcall,
     dynlib: "kernel32", importc: "LocalReAlloc".}
+proc LocalReAlloc*(hMem: HLOCAL, uBytes: DWORD, uFlags: WINUINT): HLOCAL{.stdcall,
+    dynlib: "kernel32", importc: "LocalReAlloc", deprecated.}
 proc LocalLock*(hMem: HLOCAL): LPVOID{.stdcall, dynlib: "kernel32",
                                        importc: "LocalLock".}
 proc LocalHandle*(pMem: LPCVOID): HLOCAL{.stdcall, dynlib: "kernel32",
@@ -18567,34 +18575,61 @@ proc FlushInstructionCache*(hProcess: HANDLE, lpBaseAddress: LPCVOID,
 proc VirtualAlloc*(lpAddress: LPVOID, dwSize: SIZE_T, flAllocationType: DWORD,
                    flProtect: DWORD): LPVOID{.stdcall, dynlib: "kernel32",
     importc: "VirtualAlloc".}
+proc VirtualAlloc*(lpAddress: LPVOID, dwSize: DWORD, flAllocationType: DWORD,
+                   flProtect: DWORD): LPVOID{.stdcall, dynlib: "kernel32",
+    importc: "VirtualAlloc", deprecated.}
 proc VirtualAllocEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
                      flAllocationType: DWORD, flProtect: DWORD): LPVOID
                      {.stdcall, dynlib: "kernel32", importc: "VirtualAllocEx".}
+proc VirtualAllocEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: DWORD,
+                     flAllocationType: DWORD, flProtect: DWORD): LPVOID
+                     {.stdcall, dynlib: "kernel32", importc: "VirtualAllocEx", 
+                       deprecated.}
 proc VirtualFree*(lpAddress: LPVOID, dwSize: SIZE_T, dwFreeType: DWORD): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "VirtualFree".}
+proc VirtualFree*(lpAddress: LPVOID, dwSize: DWORD, dwFreeType: DWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "VirtualFree", deprecated.}
 proc VirtualFreeEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
+                    dwFreeType: DWORD): WINBOOL
+                    {.stdcall, dynlib: "kernel32", importc: "VirtualFree".}
+proc VirtualFreeEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: DWORD,
                     dwFreeType: DWORD): WINBOOL
                     {.stdcall, dynlib: "kernel32", importc: "VirtualFree".}
 proc VirtualProtect*(lpAddress: LPVOID, dwSize: SIZE_T, flNewProtect: DWORD,
                      lpflOldProtect: PDWORD): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualProtect".}
+proc VirtualProtect*(lpAddress: LPVOID, dwSize: DWORD, flNewProtect: DWORD,
+                     lpflOldProtect: PDWORD): WINBOOL{.stdcall,
+    dynlib: "kernel32", importc: "VirtualProtect", deprecated.}
 proc VirtualQuery*(lpAddress: LPCVOID, lpBuffer: PMEMORY_BASIC_INFORMATION,
                    dwLength: DWORD): DWORD{.stdcall, dynlib: "kernel32",
     importc: "VirtualQuery".}
 proc VirtualProtectEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
                        flNewProtect: DWORD, lpflOldProtect: PDWORD): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "VirtualProtectEx".}
+proc VirtualProtectEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: DWORD,
+                       flNewProtect: DWORD, lpflOldProtect: PDWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "VirtualProtectEx", deprecated.}
 proc VirtualQueryEx*(hProcess: HANDLE, lpAddress: LPCVOID,
                      lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: SIZE_T): DWORD{.
     stdcall, dynlib: "kernel32", importc: "VirtualQueryEx".}
+proc VirtualQueryEx*(hProcess: HANDLE, lpAddress: LPCVOID,
+                     lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: DWORD): DWORD{.
+    stdcall, dynlib: "kernel32", importc: "VirtualQueryEx", deprecated.}
 proc HeapCreate*(flOptions: DWORD, dwInitialSize: SIZE_T, dwMaximumSize: SIZE_T): HANDLE{.
     stdcall, dynlib: "kernel32", importc: "HeapCreate".}
+proc HeapCreate*(flOptions: DWORD, dwInitialSize: DWORD, dwMaximumSize: DWORD): HANDLE{.
+    stdcall, dynlib: "kernel32", importc: "HeapCreate", deprecated.}
 proc HeapDestroy*(hHeap: HANDLE): WINBOOL{.stdcall, dynlib: "kernel32",
     importc: "HeapDestroy".}
 proc HeapAlloc*(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T): LPVOID{.stdcall,
     dynlib: "kernel32", importc: "HeapAlloc".}
+proc HeapAlloc*(hHeap: HANDLE, dwFlags: DWORD, dwBytes: DWORD): LPVOID{.stdcall,
+    dynlib: "kernel32", importc: "HeapAlloc", deprecated.}
 proc HeapReAlloc*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: SIZE_T): LPVOID{.
     stdcall, dynlib: "kernel32", importc: "HeapReAlloc".}
+proc HeapReAlloc*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: DWORD): LPVOID{.
+    stdcall, dynlib: "kernel32", importc: "HeapReAlloc", deprecated.}
 proc HeapFree*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "HeapFree".}
 proc HeapSize*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPCVOID): SIZE_T{.stdcall,
@@ -19229,8 +19264,12 @@ proc FindCloseChangeNotification*(hChangeHandle: HANDLE): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "FindCloseChangeNotification".}
 proc VirtualLock*(lpAddress: LPVOID, dwSize: SIZE_T): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualLock".}
+proc VirtualLock*(lpAddress: LPVOID, dwSize: DWORD): WINBOOL{.stdcall,
+    dynlib: "kernel32", importc: "VirtualLock", deprecated.}
 proc VirtualUnlock*(lpAddress: LPVOID, dwSize: SIZE_T): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualUnlock".}
+proc VirtualUnlock*(lpAddress: LPVOID, dwSize: DWORD): WINBOOL{.stdcall,
+    dynlib: "kernel32", importc: "VirtualUnlock", deprecated.}
 proc MapViewOfFileEx*(hFileMappingObject: HANDLE, dwDesiredAccess: DWORD,
                       dwFileOffsetHigh: DWORD, dwFileOffsetLow: DWORD,
                       dwNumberOfBytesToMap: DWORD, lpBaseAddress: LPVOID): LPVOID{.

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18575,17 +18575,17 @@ proc VirtualFree*(lpAddress: LPVOID, dwSize: SIZE_T, dwFreeType: DWORD): WINBOOL
 proc VirtualFreeEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
                     dwFreeType: DWORD): WINBOOL
                     {.stdcall, dynlib: "kernel32", importc: "VirtualFree".}
-proc VirtualProtect*(lpAddress: LPVOID, dwSize: DWORD, flNewProtect: DWORD,
+proc VirtualProtect*(lpAddress: LPVOID, dwSize: SIZE_T, flNewProtect: DWORD,
                      lpflOldProtect: PDWORD): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualProtect".}
 proc VirtualQuery*(lpAddress: LPCVOID, lpBuffer: PMEMORY_BASIC_INFORMATION,
                    dwLength: DWORD): DWORD{.stdcall, dynlib: "kernel32",
     importc: "VirtualQuery".}
-proc VirtualProtectEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: DWORD,
+proc VirtualProtectEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
                        flNewProtect: DWORD, lpflOldProtect: PDWORD): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "VirtualProtectEx".}
 proc VirtualQueryEx*(hProcess: HANDLE, lpAddress: LPCVOID,
-                     lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: DWORD): DWORD{.
+                     lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: SIZE_T): DWORD{.
     stdcall, dynlib: "kernel32", importc: "VirtualQueryEx".}
 proc HeapCreate*(flOptions: DWORD, dwInitialSize: DWORD, dwMaximumSize: DWORD): HANDLE{.
     stdcall, dynlib: "kernel32", importc: "HeapCreate".}

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18567,8 +18567,14 @@ proc FlushInstructionCache*(hProcess: HANDLE, lpBaseAddress: LPCVOID,
 proc VirtualAlloc*(lpAddress: LPVOID, dwSize: SIZE_T, flAllocationType: DWORD,
                    flProtect: DWORD): LPVOID{.stdcall, dynlib: "kernel32",
     importc: "VirtualAlloc".}
+proc VirtualAllocEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
+                     flAllocationType: DWORD, flProtect: DWORD): LPVOID
+                     {.stdcall, dynlib: "kernel32", importc: "VirtualAllocEx".}
 proc VirtualFree*(lpAddress: LPVOID, dwSize: SIZE_T, dwFreeType: DWORD): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "VirtualFree".}
+proc VirtualFreeEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
+                    dwFreeType: DWORD): WINBOOL
+                    {.stdcall, dynlib: "kernel32", importc: "VirtualFree".}
 proc VirtualProtect*(lpAddress: LPVOID, dwSize: DWORD, flNewProtect: DWORD,
                      lpflOldProtect: PDWORD): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualProtect".}

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18564,10 +18564,10 @@ proc LocalCompact*(uMinFree: WINUINT): WINUINT{.stdcall, dynlib: "kernel32",
 proc FlushInstructionCache*(hProcess: HANDLE, lpBaseAddress: LPCVOID,
                             dwSize: DWORD): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "FlushInstructionCache".}
-proc VirtualAlloc*(lpAddress: LPVOID, dwSize: DWORD, flAllocationType: DWORD,
+proc VirtualAlloc*(lpAddress: LPVOID, dwSize: SIZE_T, flAllocationType: DWORD,
                    flProtect: DWORD): LPVOID{.stdcall, dynlib: "kernel32",
     importc: "VirtualAlloc".}
-proc VirtualFree*(lpAddress: LPVOID, dwSize: DWORD, dwFreeType: DWORD): WINBOOL{.
+proc VirtualFree*(lpAddress: LPVOID, dwSize: SIZE_T, dwFreeType: DWORD): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "VirtualFree".}
 proc VirtualProtect*(lpAddress: LPVOID, dwSize: DWORD, flNewProtect: DWORD,
                      lpflOldProtect: PDWORD): WINBOOL{.stdcall,

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18587,21 +18587,21 @@ proc VirtualProtectEx*(hProcess: HANDLE, lpAddress: LPVOID, dwSize: SIZE_T,
 proc VirtualQueryEx*(hProcess: HANDLE, lpAddress: LPCVOID,
                      lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: SIZE_T): DWORD{.
     stdcall, dynlib: "kernel32", importc: "VirtualQueryEx".}
-proc HeapCreate*(flOptions: DWORD, dwInitialSize: DWORD, dwMaximumSize: DWORD): HANDLE{.
+proc HeapCreate*(flOptions: DWORD, dwInitialSize: SIZE_T, dwMaximumSize: SIZE_T): HANDLE{.
     stdcall, dynlib: "kernel32", importc: "HeapCreate".}
 proc HeapDestroy*(hHeap: HANDLE): WINBOOL{.stdcall, dynlib: "kernel32",
     importc: "HeapDestroy".}
-proc HeapAlloc*(hHeap: HANDLE, dwFlags: DWORD, dwBytes: DWORD): LPVOID{.stdcall,
+proc HeapAlloc*(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T): LPVOID{.stdcall,
     dynlib: "kernel32", importc: "HeapAlloc".}
-proc HeapReAlloc*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: DWORD): LPVOID{.
+proc HeapReAlloc*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: SIZE_T): LPVOID{.
     stdcall, dynlib: "kernel32", importc: "HeapReAlloc".}
 proc HeapFree*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "HeapFree".}
-proc HeapSize*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPCVOID): DWORD{.stdcall,
+proc HeapSize*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPCVOID): SIZE_T{.stdcall,
     dynlib: "kernel32", importc: "HeapSize".}
 proc HeapValidate*(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPCVOID): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "HeapValidate".}
-proc HeapCompact*(hHeap: HANDLE, dwFlags: DWORD): WINUINT{.stdcall,
+proc HeapCompact*(hHeap: HANDLE, dwFlags: DWORD): SIZE_T{.stdcall,
     dynlib: "kernel32", importc: "HeapCompact".}
 proc GetProcessHeap*(): HANDLE{.stdcall, dynlib: "kernel32",
                                 importc: "GetProcessHeap".}

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -19227,9 +19227,9 @@ proc FindNextChangeNotification*(hChangeHandle: HANDLE): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "FindNextChangeNotification".}
 proc FindCloseChangeNotification*(hChangeHandle: HANDLE): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "FindCloseChangeNotification".}
-proc VirtualLock*(lpAddress: LPVOID, dwSize: DWORD): WINBOOL{.stdcall,
+proc VirtualLock*(lpAddress: LPVOID, dwSize: SIZE_T): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualLock".}
-proc VirtualUnlock*(lpAddress: LPVOID, dwSize: DWORD): WINBOOL{.stdcall,
+proc VirtualUnlock*(lpAddress: LPVOID, dwSize: SIZE_T): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "VirtualUnlock".}
 proc MapViewOfFileEx*(hFileMappingObject: HANDLE, dwDesiredAccess: DWORD,
                       dwFileOffsetHigh: DWORD, dwFileOffsetLow: DWORD,

--- a/lib/windows/windows.nim
+++ b/lib/windows/windows.nim
@@ -18513,11 +18513,11 @@ proc DisableThreadLibraryCalls*(hLibModule: HMODULE): WINBOOL{.stdcall,
 proc GetProcAddress*(hModule: HINST, lpProcName: LPCSTR): FARPROC{.stdcall,
     dynlib: "kernel32", importc: "GetProcAddress".}
 proc GetVersion*(): DWORD{.stdcall, dynlib: "kernel32", importc: "GetVersion".}
-proc GlobalAlloc*(uFlags: int32, dwBytes: DWORD): HGLOBAL{.stdcall,
+proc GlobalAlloc*(uFlags: int32, dwBytes: SIZE_T): HGLOBAL{.stdcall,
     dynlib: "kernel32", importc: "GlobalAlloc".}
-proc GlobalReAlloc*(hMem: HGLOBAL, dwBytes: DWORD, uFlags: int32): HGLOBAL{.
+proc GlobalReAlloc*(hMem: HGLOBAL, dwBytes: SIZE_T, uFlags: int32): HGLOBAL{.
     stdcall, dynlib: "kernel32", importc: "GlobalReAlloc".}
-proc GlobalSize*(hMem: HGLOBAL): DWORD{.stdcall, dynlib: "kernel32",
+proc GlobalSize*(hMem: HGLOBAL): SIZE_T{.stdcall, dynlib: "kernel32",
                                         importc: "GlobalSize".}
 proc GlobalFlags*(hMem: HGLOBAL): WINUINT{.stdcall, dynlib: "kernel32",
                                         importc: "GlobalFlags".}
@@ -18541,9 +18541,9 @@ proc GlobalUnWire*(hMem: HGLOBAL): WINBOOL{.stdcall, dynlib: "kernel32",
     importc: "GlobalUnWire".}
 proc GlobalMemoryStatus*(lpBuffer: LPMEMORYSTATUS){.stdcall, dynlib: "kernel32",
     importc: "GlobalMemoryStatus".}
-proc LocalAlloc*(uFlags: WINUINT, uBytes: WINUINT): HLOCAL{.stdcall,
+proc LocalAlloc*(uFlags: WINUINT, uBytes: SIZE_T): HLOCAL{.stdcall,
     dynlib: "kernel32", importc: "LocalAlloc".}
-proc LocalReAlloc*(hMem: HLOCAL, uBytes: WINUINT, uFlags: WINUINT): HLOCAL{.stdcall,
+proc LocalReAlloc*(hMem: HLOCAL, uBytes: SIZE_T, uFlags: WINUINT): HLOCAL{.stdcall,
     dynlib: "kernel32", importc: "LocalReAlloc".}
 proc LocalLock*(hMem: HLOCAL): LPVOID{.stdcall, dynlib: "kernel32",
                                        importc: "LocalLock".}


### PR DESCRIPTION
These are the out of process equivalents of VirtualAlloc and VirtualFree.  Tested on 32 bit and 64 bit environments. 