### PR TITLE
Removed -mwindows option from clang invocation.

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -103,6 +103,7 @@ compiler clang:
   result.name = "clang"
   result.compilerExe = "clang"
   result.cppCompiler = "clang++"
+  result.buildGui = ""
 
 # Microsoft Visual C/C++ Compiler
 compiler vcc:


### PR DESCRIPTION
I could not find anywhere that clang supports -mwindows option, unfortunately I don't have windows to test it. But since clang is not stable on windows anyway, I guess it could be ignored for now.

Fixes #2576

This is a reopen of #2587. Could not reopen that one after a force push.