### PR TITLE
Corrected gcc path on windows

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -96,7 +96,7 @@ path="$lib/pure/unidecode"
 
 # Configuration for the GNU C/C++ compiler:
 @if windows:
-  #gcc.path = r"$nimrod\dist\mingw\bin"
+  #gcc.path = r"$nim\dist\mingw\bin"
   @if gcc:
     tlsEmulation:on
   @end


### PR DESCRIPTION
When gcc path is set to  r"$nimrod\dist\mingw\bin", the compiler gives
an error:
Error : unhandled exception : invalid format string [Value Error], but
works correctly with gcc.path set to r"$nim\dist\mingw\bin". I think
this issue was caused due to the name change from nimrod to nim , but
the name change was not replicated in the config file.