### PR TITLE
fixes isPowerOfTwo returning true on the smallest integer

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -85,7 +85,7 @@ proc fac*(n: int): int {.noSideEffect.} =
 proc isPowerOfTwo*(x: int): bool {.noSideEffect.} =
   ## returns true, if `x` is a power of two, false otherwise.
   ## Zero and negative numbers are not a power of two.
-  return (x != 0) and ((x and (x - 1)) == 0)
+  return (x > 0) and ((x and (x - 1)) == 0)
 
 proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
   ## returns `x` rounded up to the nearest power of two.


### PR DESCRIPTION
isPowerOfTwo returns true on the smallest integer, while it shouldn't on any negative integer. This patch fixes that.

echo 1 shl 63, " power of two ? ", isPowerOfTwo(1 shl 63)
->
-9223372036854775808 power of two ? true