### PR TITLE
Fix the lib path used with --app:staticlib

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -668,7 +668,7 @@ proc callCCompiler*(projectfile: string) =
       it = PStrEntry(it.next)
 
     if optGenStaticLib in gGlobalOptions:
-      let (_, name, _) = splitFile(gProjectName)
+      let name = splitFile(gProjectName).name
       linkCmd = CC[c].buildLib % ["libfile", (libNameTmpl() % name),
                                   "objfiles", objfiles]
     else:

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -668,7 +668,8 @@ proc callCCompiler*(projectfile: string) =
       it = PStrEntry(it.next)
 
     if optGenStaticLib in gGlobalOptions:
-      linkCmd = CC[c].buildLib % ["libfile", (libNameTmpl() % gProjectName),
+      let (_, name, _) = splitFile(gProjectName)
+      linkCmd = CC[c].buildLib % ["libfile", (libNameTmpl() % name),
                                   "objfiles", objfiles]
     else:
       var linkerExe = getConfigVar(c, ".linkerexe")


### PR DESCRIPTION
For example if gProjectName is "src/false.nim" the old static lib name was "libsrc/false.nim.a", now it is "libfalse.a".