### PR TITLE
Fixup: csources is empty after clone

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-if [ ! -d "csources" ]; then
+if [ ! -e csources/.git ]; then
 	git submodule update --init --depth 1
 fi
 


### PR DESCRIPTION
We actually need to check for existence of csources/.git and then do git
submodule update --init, which pulls the data for submodule.

@Araq I am sorry, I totally forgot Git leaves `csources` (and any submodule dir) empty after initial clone of main repo.