### PR TITLE
Add -ldl with clang cpp compilation

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -78,6 +78,7 @@ path="$lib/pure/unidecode"
     gcc.options.linker = "-ldl"
     gcc.cpp.options.linker = "-ldl"
     clang.options.linker = "-ldl"
+    clang.cpp.options.linker = "-ldl"
     tcc.options.linker = "-ldl"
   @end
   @if bsd or haiku:


### PR DESCRIPTION
This fixes compilation with --cc:clang and cpp.

There is still the problem that clang++ doesn't like conversions from `const type` to `type` and even `-fpermissive` (which fixed it for g++) doesn't help. See for example the rawsockets module.