### PR TITLE
Unittest.nim: Show test name on failure

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -91,7 +91,7 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
   bind shouldRun, checkpoints, testDone
 
   if shouldRun(name):
-    checkpoints = @[]
+    checkpoints = @[ "Test: " & $name ]
     var testStatusIMPL {.inject.} = OK
 
     try:


### PR DESCRIPTION
Not much to add here, as this is a small change. When a test fails, the name of that test is included in the error message.

One note: I could put this behind a test to check that `string($name)` compiles, but it looks like there is already other code that assumes `name` is a string. `testDone`, for example