### PR TITLE
Fix behavior of os.getFileInfo() for symbolic links.

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2033,10 +2033,10 @@ proc getFileInfo*(path: string, followSymlink = true): FileInfo =
   else:
     var rawInfo: TStat
     if followSymlink:
-      if lstat(path, rawInfo) < 0'i32:
+      if stat(path, rawInfo) < 0'i32:
         raiseOSError(osLastError())
     else:
-      if stat(path, rawInfo) < 0'i32:
+      if lstat(path, rawInfo) < 0'i32:
         raiseOSError(osLastError())
     rawToFormalFileInfo(rawInfo, result)
 


### PR DESCRIPTION
The calls to lstat() and stat() were switched. As a result,
links weren't followed for followLink == true and links were
followed for followLink == false.