### PR TITLE
Fix #2662: Don't convert subtype typedesc params

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1281,7 +1281,10 @@ proc paramTypesMatchAux(m: var TCandidate, f, argType: PType,
     result = implicitConv(nkHiddenStdConv, f, arg, m, c)
   of isSubtype:
     inc(m.subtypeMatches)
-    result = implicitConv(nkHiddenSubConv, f, arg, m, c)
+    if f.kind == tyTypeDesc:
+      result = arg
+    else:
+      result = implicitConv(nkHiddenSubConv, f, arg, m, c)
   of isSubrange:
     inc(m.subtypeMatches)
     if f.kind == tyVar:

--- a/tests/metatype/ttypedesc3.nim
+++ b/tests/metatype/ttypedesc3.nim
@@ -1,0 +1,19 @@
+import typetraits
+
+type
+  Base = object of RootObj
+  Child = object of Base
+
+proc pr(T: typedesc[Base]) = echo "proc " & T.name
+method me(T: typedesc[Base]) = echo "method " & T.name
+iterator it(T: typedesc[Base]) = yield "yield " & T.name
+
+Base.pr
+Child.pr
+
+Base.me
+when false:
+  Child.me #<- bug #2710
+
+for s in Base.it: echo s
+for s in Child.it: echo s #<- bug #2662


### PR DESCRIPTION
There is no point to issue implicit `HiddenStdConv` encountering subtype of
`typedesc[Base]` parameter on overload resolution, since this will anyway never
reach codegen. This change effectively fixes compiler bug for:

~~~nim
iterator it(T: typedesc[Base]) = ...
for s in it(SubclassOfBase): ...
~~~

Where `HiddenStdConv` triggered implicit instantiation of variable of type
typedesc[Base] in `for` transform, that eventually fails at `getUniqueType`, that
refuses to work for `typedesc`.