### PR TITLE
Macros: Introduce typeNode(t: typedesc): NimNode

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -177,6 +177,12 @@ proc getType*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
   ## resolve recursive types, you have to call 'getType' again. To see what
   ## kind of type it is, call `typeKind` on getType's result.
 
+proc getType*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
+  ## Returns the Nim type node for given type. This can be used to turn macro
+  ## typedesc parameter into proper NimNode representing type, since typedesc
+  ## are an exception in macro calls - they are not mapped implicitly to
+  ## NimNode like any other arguments.
+
 proc typeKind*(n: NimNode): NimTypeKind {.magic: "NGetType", noSideEffect.}
   ## Returns the type kind of the node 'n' that should represent a type, that
   ## means the node should have been obtained via `getType`.

--- a/tests/macros/tgettype.nim
+++ b/tests/macros/tgettype.nim
@@ -1,0 +1,20 @@
+discard """
+msg: '''ObjectTy(Sym(Model), RecList(Sym(name), Sym(password)))
+BracketExpr(Sym(typeDesc), Sym(User))'''
+"""
+import strutils, macros
+
+type
+  Model = object of RootObj
+  User = object of Model
+    name : string
+    password : string
+
+macro testUser: expr =
+  return newLit(User.getType.lispRepr)
+
+macro testGeneric(T: typedesc[Model]): expr =
+  return newLit(T.getType.lispRepr)
+
+echo testUser
+echo User.testGeneric


### PR DESCRIPTION
Since typedesc are exception in macros and they are not implicitly converted to
NimNode on macro call, we need some means to perform such conversion on demand.

Fortunately it is as simple as declaring new magic "NGetType" proc with
typedesc parameter.

NOTE: Keeping actual typedesc exception behavior is important, since it allows
passing typedesc macro parameter to other procs or macros expecting type
parameter. If typedesc parameter was implicitly converted, then we would lost
this ability.