### PR TITLE
Small sequence fix for algorithm.nim

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -232,7 +232,7 @@ template sortedByIt*(seq1, op: expr): expr =
 proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
   ## produces the Cartesian product of the array. Warning: complexity
   ## may explode.
-  result = @[]
+  result = newSeq[seq[T]]()
   if x.len == 0:
     return
   if x.len == 1:
@@ -242,8 +242,7 @@ proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
     indexes = newSeq[int](x.len)
     initial = newSeq[int](x.len)
     index = 0
-  # replace with newSeq as soon as #853 is fixed
-  var next: seq[T] = @[]
+  var next = newSeq[T]()
   next.setLen(x.len)
   for i in 0..(x.len-1):
     if len(x[i]) == 0: return


### PR DESCRIPTION
Since #853 was fixed, this should work fine. The `result = @[]` was swapped to the same syntax, too.