### PR TITLE
C gen: noSideEffect should emit __attribute__((pure))

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -727,6 +727,9 @@ proc genProcPrototype(m: BModule, sym: PSym) =
       header.add(" __attribute__((naked))")
     if sfNoReturn in sym.flags and hasAttribute in CC[cCompiler].props:
       header.add(" __attribute__((noreturn))")
+    if sfNoSideEffect in sym.flags and not (sfSideEffect in sym.flags) and
+       hasAttribute in CC[cCompiler].props:
+      header.add(" __attribute__((pure))")
     add(m.s[cfsProcHeaders], rfmt(nil, "$1;$n", header))
 
 proc genProcNoForward(m: BModule, prc: PSym) =


### PR DESCRIPTION
#### Do not merge this yet!

Currently this causes Nim compiler to not compile itself at all, because some procs marked with `noSideEffects` likely violate this, but Nim compiler fails to analyze that and mark proc with `sfSideEffect`, as a result we get:

~~~
iteration: 3
compiler/nim2 c -d:release compiler/nim.nim
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
FAILURE
~~~

But I think in principle checking `sfNoSideEffect in sym.flags and not (sfSideEffect in sym.flags)` should be enough to mark emitted C code with `__attribute__((pure))`.

### Original change description

[pure]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-g_t_0040code_007boptimize_007d-function-attribute-3107

Nim's definition of `{.noSideEffect.}` matches exactly GCC's (Clang's)
definition of `pure` function (see [GCC's pure attribute][pure]), therefore we
should mark Nim's no side-effect procs with this C attribute. This will allow
great code optimizations, letting C compiler remove some function calls whose
return value is going to be optimized out, eg. lazy calls to database API calls
in Nim's db modules.