### PR TITLE
Intval

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1121,7 +1121,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeB(rkInt)
       let a = regs[rb].node
       case a.kind
-      of nkCharLit..nkInt64Lit: regs[ra].intVal = a.intVal
+      of nkCharLit..nkUInt64Lit: regs[ra].intVal = a.intVal
       else: stackTrace(c, tos, pc, errFieldXNotFound, "intVal")
     of opcNFloatVal:
       decodeB(rkFloat)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1276,7 +1276,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNSetIntVal:
       decodeB(rkNode)
       var dest = regs[ra].node
-      if dest.kind in {nkCharLit..nkInt64Lit} and
+      if dest.kind in {nkCharLit..nkUInt64Lit} and
          regs[rb].kind in {rkInt}:
         dest.intVal = regs[rb].intVal
       else:

--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -23,7 +23,7 @@ contains:
       case kind: NimNodeKind           ## the node's kind
       of nnkNone, nnkEmpty, nnkNilLit:
         discard                        ## node contains no additional fields
-      of nnkCharLit..nnkInt64Lit:
+      of nnkCharLit..nnkUInt64Lit:
         intVal: biggestInt             ## the int literal
       of nnkFloatLit..nnkFloat64Lit:
         floatVal: biggestFloat         ## the float literal


### PR DESCRIPTION
Make intVal work for uint literals in the VM. This fixes the bug repoted here: https://stackoverflow.com/questions/30311110/how-to-create-a-nnkuint16lit-nimnode/