### PR TITLE
Fix asyncdispatch.async bug with discard stmt

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1328,7 +1328,7 @@ proc processBody(node, retFutureSym: NimNode,
     else: discard
   of nnkDiscardStmt:
     # discard await x
-    if node[0].kind != nnkEmpty and node[0][0].kind == nnkIdent and
+    if node[0].kind == nnkCommand and node[0][0].kind == nnkIdent and
           node[0][0].ident == !"await":
       var newDiscard = node
       result.createVar("futureDiscard_" & $toStrLit(node[0][1]), node[0][1],


### PR DESCRIPTION
Fixes a bug with asyncdispatch.async and discard statements with non-call params. Eg:

```nim
import asyncdispatch

proc testDiscard {.async.} =
  discard "this was broken"
  echo "now it's fixed"

waitFor testDiscard()
```