### PR TITLE
Corrected various links within documentation

### DIFF
--- a/doc/manual/stmts.txt
+++ b/doc/manual/stmts.txt
@@ -176,9 +176,9 @@ The rules for compile-time computability are:
 1. Literals are compile-time computable.
 2. Type conversions are compile-time computable.
 3. Procedure calls of the form ``p(X)`` are compile-time computable if
-   ``p`` is a proc without side-effects (see the `noSideEffect pragma`_
-   for details) and if ``X`` is a (possibly empty) list of compile-time
-   computable arguments.
+   ``p`` is a proc without side-effects (see the `noSideEffect pragma 
+   <#pragmas-nosideeffect-pragma>`_ for details) and if ``X`` is a 
+   (possibly empty) list of compile-time computable arguments.
 
 
 Constants cannot be of type ``ptr``, ``ref``, ``var`` or ``object``, nor can

--- a/doc/manual/types.txt
+++ b/doc/manual/types.txt
@@ -963,7 +963,7 @@ Most calling conventions exist only for the Windows 32-bit platform.
 Assigning/passing a procedure to a procedural variable is only allowed if one
 of the following conditions hold:
 1) The procedure that is accessed resides in the current module.
-2) The procedure is marked with the ``procvar`` pragma (see `procvar pragma`_).
+2) The procedure is marked with the ``procvar`` pragma (see `procvar pragma <#pragmas-procvar-pragma>`_).
 3) The procedure has a calling convention that differs from ``nimcall``.
 4) The procedure is anonymous.
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2248,14 +2248,14 @@ proc echo*(x: varargs[expr, `$`]) {.magic: "Echo", tags: [WriteIOEffect],
   ## Unlike other IO operations this is guaranteed to be thread-safe as
   ## ``echo`` is very often used for debugging convenience. If you want to use
   ## ``echo`` inside a `proc without side effects
-  ## <manual.html#nosideeffect-pragma>`_ you can use `debugEcho <#debugEcho>`_
+  ## <manual.html#pragmas-nosideeffect-pragma>`_ you can use `debugEcho <#debugEcho>`_
   ## instead.
 
 proc debugEcho*(x: varargs[expr, `$`]) {.magic: "Echo", noSideEffect,
                                            tags: [], raises: [].}
   ## Same as `echo <#echo>`_, but as a special semantic rule, ``debugEcho``
   ## pretends to be free of side effects, so that it can be used for debugging
-  ## routines marked as `noSideEffect <manual.html#nosideeffect-pragma>`_.
+  ## routines marked as `noSideEffect <manual.html#pragmas-nosideeffect-pragma>`_.
 
 template newException*(exceptn: typedesc, message: string): expr =
   ## creates an exception object of type ``exceptn`` and sets its ``msg`` field


### PR DESCRIPTION
* Corrected `noSideEffect pragma` links in lib/system (the newer documentation uses slightly different links)
* Corrected `noSideEffect pragma` in types.txt links to match the updated link names
* Minor link adjustment in stmts.txt to match the newer link names