### PR TITLE
Introduce pedantic mode for tester

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -333,8 +333,10 @@ proc tests(args: string) =
   # taint mode test :-)
   exec "nim cc --taintMode:on tests/testament/tester"
   let tester = quoteShell(getCurrentDir() / "tests/testament/tester".exe)
-  exec tester & " " & (args|"all")
+  let success = tryExec tester & " " & (args|"all")
   exec tester & " html"
+  if not success:
+    quit("tests failed", QuitFailure)
 
 proc temp(args: string) =
   var output = "compiler" / "nim".exe

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -31,6 +31,7 @@ Arguments:
 Options:
   --print                   also print results to the console
   --failing                 only show failing/ignored tests
+  --pedantic                return non-zero status code if there are failures
 """ % resultsFile
 
 type
@@ -310,12 +311,14 @@ proc main() =
   backend.open()
   var optPrintResults = false
   var optFailing = false
+  var optPedantic = false
   var p = initOptParser()
   p.next()
   while p.kind == cmdLongoption:
     case p.key.string.normalize
     of "print", "verbose": optPrintResults = true
     of "failing": optFailing = true
+    of "pedantic": optPedantic = true
     else: quit Usage
     p.next()
   if p.kind != cmdArgument: quit Usage
@@ -348,8 +351,10 @@ proc main() =
     if action == "html": openDefaultBrowser(resultsFile)
     else: echo r, r.data
   backend.close()
+  if optPedantic:
+    var failed = r.total - r.passed - r.skipped
+    if failed > 0 : quit(QuitFailure)
 
 if paramCount() == 0:
   quit Usage
 main()
-


### PR DESCRIPTION
Motivation
----------
External tools need to know whether or not any test in suite failed. For
example buildbot, or packaging tool would like to stop the execution and
mark it as failed if some tests does not pass.

Modification
------------
Add `--pedantic` switch to tester program which will force it to quit
with non-zero exit code if at least one failure detected. Also update
`tests()` proc in koch to inspect result from tester and propagate it to
user.

Result
------
Nothing has changed in default behaviour. But following invocations will
exit with non-zero code if there failed tests:

    ./koch tests --pedantic all
    ./tests/testament/tester --pedantic all

Fixes #2793