### PR TITLE
Fix Boehm GC on linux

### DIFF
--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -70,7 +70,7 @@ when defined(boehmgc):
   elif defined(macosx):
     const boehmLib = "libgc.dylib"
   else:
-    const boehmLib = "/usr/lib/libgc.so.1"
+    const boehmLib = "libgc.so.1"
 
   proc boehmGCinit {.importc: "GC_init", dynlib: boehmLib.}
   proc boehmGC_disable {.importc: "GC_disable", dynlib: boehmLib.}
@@ -335,4 +335,3 @@ else:
     include "system/gc"
 
 {.pop.}
-


### PR DESCRIPTION
Motivation
----------
Some linuxes (like Fedora) actually multiarch. And it means that
libgc.so.1 not always installed into /usr/lib. It is better to entrust
this job to ld and system configuration for it.

Modification
------------
Use relative path for Boehm GC on 'other' OS (and linux in particular)

Result
------
It is possible now to build nim with --gc:boehm on linux