### PR TITLE
Perform lambda lifting for compile-time stuff when targeting JS.

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -946,7 +946,11 @@ proc transformOuterProc(o: POuterContext, n: PNode; it: TIter): PNode =
 proc liftLambdas*(fn: PSym, body: PNode): PNode =
   # XXX gCmd == cmdCompileToJS does not suffice! The compiletime stuff needs
   # the transformation even when compiling to JS ...
-  if body.kind == nkEmpty or gCmd == cmdCompileToJS or
+
+  # However we can do lifting for the stuff which is *only* compiletime.
+  let isCompileTime = sfCompileTime in fn.flags or fn.kind == skMacro
+
+  if body.kind == nkEmpty or (gCmd == cmdCompileToJS and not isCompileTime) or
       fn.skipGenericOwner.kind != skModule:
     # ignore forward declaration:
     result = body

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -99,8 +99,9 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
       body
 
     except:
-      checkpoint("Unhandled exception: " & getCurrentExceptionMsg())
-      echo getCurrentException().getStackTrace()
+      when not defined(js):
+        checkpoint("Unhandled exception: " & getCurrentExceptionMsg())
+        echo getCurrentException().getStackTrace()
       fail()
 
     finally:
@@ -114,9 +115,7 @@ proc checkpoint*(msg: string) =
 template fail* =
   bind checkpoints
   for msg in items(checkpoints):
-    # this used to be 'echo' which now breaks due to a bug. XXX will revisit
-    # this issue later.
-    stdout.writeln msg
+    echo msg
 
   when not defined(ECMAScript):
     if abortOnError: quit(1)

--- a/tests/js/tunittests.nim
+++ b/tests/js/tunittests.nim
@@ -1,9 +1,6 @@
 discard """
-  disabled: "true"
+  output: '''[OK] >:)'''
 """
-
-# Unittest uses lambdalifting at compile-time which we disable for the JS
-# codegen! So this cannot and will not work for quite some time.
 
 import unittest
 


### PR DESCRIPTION
The reasoning behind this commit is to enable lambda lifting for JavaScript, but only for the stuff that is only compile time. Inspired by disabled js/tunittest, which is enabled in this PR. Also had to do a couple of changes in unittest.nim, among which changing writeln to echo. I'm not 100% sure about it because of Araq's comment nearby.