### PR TITLE
Macros: Introduce currentStmt macro helper

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -583,7 +583,7 @@ type
     mNIntVal, mNFloatVal, mNSymbol, mNIdent, mNGetType, mNStrVal, mNSetIntVal,
     mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetType, mNSetStrVal, mNLineInfo,
     mNNewNimNode, mNCopyNimNode, mNCopyNimTree, mStrToIdent, mIdentToStr,
-    mNBindSym, mLocals, mNCallSite,
+    mNBindSym, mLocals, mNCallSite, mNCurrentStmt,
     mEqIdent, mEqNimrodNode, mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo, mNGenSym
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -355,7 +355,7 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   #if c.evalContext == nil:
   #  c.evalContext = c.createEvalContext(emStatic)
 
-  result = evalMacroCall(c.module, n, nOrig, sym)
+  result = evalMacroCall(c.module, n, nOrig, sym, c.currentStmt)
   if efNoSemCheck notin flags:
     result = semAfterMacroCall(c, result, sym, flags)
   popInfoContext()

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -56,6 +56,7 @@ type
   PContext* = ref TContext
   TContext* = object of TPassContext # a context represents a module
     module*: PSym              # the module sym belonging to the context
+    currentStmt*: PNode        # pointer to current statement
     currentScope*: PScope      # current scope
     importTable*: PScope       # scope for all imported symbols
     topLevelScope*: PScope     # scope for all top-level symbols

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1351,7 +1351,10 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
       n.typ = n.sons[i].typ
       return
     else:
+      let parentStmt = c.currentStmt
+      c.currentStmt = n.sons[i]
       n.sons[i] = semExpr(c, n.sons[i])
+      c.currentStmt = parentStmt
       if c.inTypeClass > 0 and n[i].typ != nil:
         case n[i].typ.kind
         of tyBool:
@@ -1404,8 +1407,11 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
         #  "is discardable or discarded")
 
 proc semStmt(c: PContext, n: PNode): PNode =
+  let parentStmt = c.currentStmt
+  c.currentStmt = n
   # now: simply an alias:
   result = semExprNoType(c, n)
+  c.currentStmt = parentStmt
 
 proc semStmtScope(c: PContext, n: PNode): PNode =
   openScope(c)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1216,6 +1216,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       ensureKind(rkNode)
       if c.callsite != nil: regs[ra].node = c.callsite
       else: stackTrace(c, tos, pc, errFieldXNotFound, "callsite")
+    of opcCurrentStmt:
+      ensureKind(rkNode)
+      if c.currentStmt != nil: regs[ra].node = c.currentStmt
+      else: stackTrace(c, tos, pc, errFieldXNotFound, "currentStmt")
     of opcNLineInfo:
       decodeB(rkNode)
       let n = regs[rb].node
@@ -1474,7 +1478,8 @@ proc setupMacroParam(x: PNode): PNode =
 
 var evalMacroCounter: int
 
-proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym): PNode =
+proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym,
+                    currentStmt: PNode): PNode =
   # XXX GlobalError() is ugly here, but I don't know a better solution for now
   inc(evalMacroCounter)
   if evalMacroCounter > 100:
@@ -1491,6 +1496,7 @@ proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym): PNode =
   var c = globalCtx
 
   c.callsite = nOrig
+  c.currentStmt = currentStmt
   let start = genProc(c, sym)
 
   var tos = PStackFrame(prc: sym, comesFrom: 0, next: nil)

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -110,6 +110,7 @@ type
     opcNChild,
     opcNSetChild,
     opcCallSite,
+    opcCurrentStmt,
     opcNewStr,
 
     opcTJmp,  # jump Bx if A != 0
@@ -194,6 +195,7 @@ type
     prc*: PProc
     module*: PSym
     callsite*: PNode
+    currentStmt*: PNode
     mode*: TEvalMode
     features*: TSandboxFlags
     traceActive*: bool

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1011,6 +1011,9 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNCallSite:
     if dest < 0: dest = c.getTemp(n.typ)
     c.gABC(n, opcCallSite, dest)
+  of mNCurrentStmt:
+    if dest < 0: dest = c.getTemp(n.typ)
+    c.gABC(n, opcCurrentStmt, dest)
   of mNGenSym: genBinaryABC(c, n, dest, opcGenSym)
   of mMinI, mMaxI, mAbsF64, mMinF64, mMaxF64, mAbsI,
      mAbsI64, mDotDot:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -273,6 +273,10 @@ proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
 proc callsite*(): NimNode {.magic: "NCallSite", benign.}
   ## returns the AST of the invocation expression that invoked this macro.
 
+proc currentStmt*(): NimNode {.magic: "NCurrentStmt", benign.}
+  ## returns the AST of the statement that invoked this macro.
+  ## The returned node should not be modified by any means.
+
 proc toStrLit*(n: NimNode): NimNode {.compileTime.} =
   ## converts the AST `n` to the concrete Nim code and wraps that
   ## in a string literal node

--- a/tests/macros/tcurrentstmt.nim
+++ b/tests/macros/tcurrentstmt.nim
@@ -1,0 +1,9 @@
+import macros
+
+macro test(st: expr): expr =
+  echo st.lispRepr
+  echo currentStmt().lispRepr
+  st
+
+if test(1) == 1:
+  echo test(2) + 2


### PR DESCRIPTION
This is useful for macros for looking around its invocation context. However
this will be very unsafe to modify returned statement node.

Example application can be macro parsing given untyped expression depending on
the variable name given in the for loop:

```nim
for obj in iterMacro(obj.id == 1): #<- okay
  echo obj.name

for obj in iterMacro(var.id == 1): #<- macro raises error, unknown variable "var"
  echo obj.name
```

@Araq: This modification lets ORM db optimizations we discussed without extra syntax, since macro will be now able to see the untyped block code, and infer what fields are used going through that.

Only problem I can see there is that template resolution in `for` body will happen after the macro invocation, so macro will be not able to infer fields when using some template calls. This is chicken-egg problem unfortunately.
