### PR TITLE
fix for https://github.com/nim-lang/Aporia/issues/69

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -262,7 +262,7 @@ else:
   else:
     const iconvDll = "(libc.so.6|libiconv.so)"
 
-  when defined(macosx) and defined(powerpc):
+  when defined(macosx):
     const prefix = "lib"
   else:
     const prefix = ""


### PR DESCRIPTION
Problem: after building aporia on a mac, it could not be started with the error message "could not import: iconv_open" A solution to this is described in https://github.com/nim-lang/Aporia/issues/69. I did the described changes and afterwards, aporia could be started. This the PR that dom96 asked for. As far as I could see, there was no PR for this yet.