### PR TITLE
Export newSocket(fd) from net.nim and standardize args in net/asyncnet

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -91,13 +91,13 @@ type
 
 # TODO: Save AF, domain etc info and reuse it in procs which need it like connect.
 
-proc newAsyncSocket*(fd: TAsyncFD, isBuff: bool): AsyncSocket =
+proc newAsyncSocket*(fd: TAsyncFD, buffered = true): AsyncSocket =
   ## Creates a new ``AsyncSocket`` based on the supplied params.
   assert fd != osInvalidSocket.TAsyncFD
   new(result)
   result.fd = fd.SocketHandle
-  result.isBuffered = isBuff
-  if isBuff:
+  result.isBuffered = buffered
+  if buffered:
     result.currPos = 0
 
 proc newAsyncSocket*(domain: Domain = AF_INET, typ: SockType = SOCK_STREAM,

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -118,13 +118,13 @@ proc toOSFlags*(socketFlags: set[SocketFlag]): cint =
       result = result or MSG_PEEK
     of SocketFlag.SafeDisconn: continue
 
-proc newSocket(fd: SocketHandle, isBuff: bool): Socket =
+proc newSocket*(fd: SocketHandle, buffered = true): Socket =
   ## Creates a new socket as specified by the params.
   assert fd != osInvalidSocket
   new(result)
   result.fd = fd
-  result.isBuffered = isBuff
-  if isBuff:
+  result.isBuffered = buffered
+  if buffered:
     result.currPos = 0
 
 proc newSocket*(domain, typ, protocol: cint, buffered = true): Socket =


### PR DESCRIPTION
Exporting newSocket(fd) mimics what asyncnet does and lets you pass in your own socket FD.
newSocket\*(fd) and newAsyncSocket\*(fd) now both take "buffered" instead of "isBuff" and defaults to true to match the other constructors on both.