### PR TITLE
Feature #2811 hump, snake and now dash

### DIFF
--- a/compiler/idents.nim
+++ b/compiler/idents.nim
@@ -12,7 +12,7 @@
 # id. This module is essential for the compiler's performance.
 
 import 
-  hashes, strutils
+  hashes, strutils, etcpriv
 
 type 
   TIdObj* = object of RootObj
@@ -37,6 +37,8 @@ proc cmpIgnoreStyle(a, b: cstring, blen: int): int =
   while j < blen:
     while a[i] == '_': inc(i)
     while b[j] == '_': inc(j)
+    while isMagicIdentSeparatorRune(a, i): inc(i, magicIdentSeparatorRuneByteWidth)
+    while isMagicIdentSeparatorRune(b, j): inc(j, magicIdentSeparatorRuneByteWidth)
     # tolower inlined:
     var aa = a[i]
     var bb = b[j]

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -140,7 +140,8 @@ proc isKeyword*(kind: TTokType): bool =
 proc isNimIdentifier*(s: string): bool =
   if s[0] in SymStartChars:
     var i = 1
-    while i < s.len:
+    var sLen = s.len
+    while i < sLen:
       if s[i] == '_':
         inc(i)
       elif isMagicIdentSeparatorRune(cstring s, i):
@@ -637,7 +638,7 @@ proc getSymbol(L: var TLexer, tok: var TToken) =
           buf[pos+1] == '\128' and
           buf[pos+2] == '\147':  # It's a 'magic separator' en-dash Unicode
         if buf[pos + magicIdentSeparatorRuneByteWidth] notin SymChars:
-          lexMessage(L, errInvalidToken, "·")
+          lexMessage(L, errInvalidToken, "–")
           break
         inc(pos, magicIdentSeparatorRuneByteWidth)
       else:

--- a/lib/pure/etcpriv.nim
+++ b/lib/pure/etcpriv.nim
@@ -1,0 +1,23 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2015 Nim Authors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module contains utils that are less then easy to categorize and
+## don't really warrant a specific module. They are private to compiler
+## and stdlib usage, and should not be used outside of that - they may
+## change or disappear at any time.
+
+
+# Used by pure/hashes.nim, and the compiler parsing
+const magicIdentSeparatorRuneByteWidth* = 3
+
+# Used by pure/hashes.nim, and the compiler parsing
+proc isMagicIdentSeparatorRune*(cs: cstring, i: int): bool  {. inline } =
+  result =  cs[i] == '\226' and 
+            cs[i + 1] == '\128' and
+            cs[i + 2] == '\147'     # en-dash  # 145 = nb-hyphen

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -38,7 +38,7 @@
 ##    result = !$h
 
 import
-  strutils
+  strutils, etcpriv
 
 type
   THash* = int ## a hash value; hash tables using these values should
@@ -124,13 +124,21 @@ proc hash*(x: string): THash =
 proc hashIgnoreStyle*(x: string): THash =
   ## efficient hashing of strings; style is ignored
   var h: THash = 0
-  for i in 0..x.len-1:
+  var i = 0
+  let xLen = x.len
+  while i < xLen:
     var c = x[i]
     if c == '_':
+      inc(i)
       continue                # skip _
+    if isMagicIdentSeparatorRune(cstring(x), i):
+      inc(i, magicIdentSeparatorRuneByteWidth)
+      continue                # skip '·' (unicode middle dot)
     if c in {'A'..'Z'}:
       c = chr(ord(c) + (ord('a') - ord('A'))) # toLower()
     h = h !& ord(c)
+    inc(i)
+
   result = !$h
 
 proc hashIgnoreCase*(x: string): THash =

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -130,14 +130,13 @@ proc hashIgnoreStyle*(x: string): THash =
     var c = x[i]
     if c == '_':
       inc(i)
-      continue                # skip _
-    if isMagicIdentSeparatorRune(cstring(x), i):
+    elif isMagicIdentSeparatorRune(cstring(x), i):
       inc(i, magicIdentSeparatorRuneByteWidth)
-      continue                # skip '·' (unicode middle dot)
-    if c in {'A'..'Z'}:
-      c = chr(ord(c) + (ord('a') - ord('A'))) # toLower()
-    h = h !& ord(c)
-    inc(i)
+    else:
+      if c in {'A'..'Z'}:
+        c = chr(ord(c) + (ord('a') - ord('A'))) # toLower()
+      h = h !& ord(c)
+      inc(i)
 
   result = !$h
 


### PR DESCRIPTION
#### Motivation ####
- Unicode runes are allowed in identifers in Nim
- This aims to solve compatibility between humpStyle, snake_style and, by making EN-DASH (U+2013) magic like the former mentioned, to also allow dash–style identifiers to be used by any of the styles preferred.

#### The chosen rune / glyph `–` (U+2013) ####
- The glyph is clearly distinguishable from minus, for those who don't use the style - if they for some reason would read such code. It ties the words together in a great fashion.
- It has wide font support
- Easily typed in many OSes, otherwise easily configured via .xmodmap.

#### The code ####
- I've compared the utf-8 encoded byte sequence directly, instead of converting to a code point and comparing. This makes the code more isolated and efficient, in line with the hotness of the code path.
- Should I add a unit-test, or is it overkill?
- There's a constant and a proc that is needed by both lib/pure and compiler source, I put it in `pure/etcpriv.nim`. For "et c. stuff that is compiler/lib internal private".

This is my first dive in to the compiler - so keep eyes open so I haven't done anything retarded ;-)