### PR TITLE
In logging.nim, expose bufSize parameter for file-based loggers

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -82,7 +82,7 @@ type
     baseName: string # initial filename
     baseMode: FileMode # initial file mode
     logFiles: int # how many log files already created, e.g. basename.1, basename.2...
-    bufSize: int # size of output buffer (-1: automatic, 0: unbuffered, >0: fixed buffer size)
+    bufSize: int # size of output buffer (-1: use system defaults, 0: unbuffered, >0: fixed buffer size)
 
 {.deprecated: [TLevel: Level, PLogger: Logger, PConsoleLogger: ConsoleLogger,
     PFileLogger: FileLogger, PRollingFileLogger: RollingFileLogger].}
@@ -152,6 +152,8 @@ proc newFileLogger*(filename = defaultFilename(),
                     fmtStr = defaultFmtStr,
                     bufSize: int = -1): FileLogger =
   ## Creates a new file logger. This logger logs to a file.
+  ## Use ``bufSize`` as size of the output buffer when writing the file
+  ## (-1: use system defaults, 0: unbuffered, >0: fixed buffer size).
   new(result)
   result.levelThreshold = levelThreshold
   result.f = open(filename, mode, bufSize = bufSize)
@@ -187,6 +189,8 @@ proc newRollingFileLogger*(filename = defaultFilename(),
                            bufSize: int = -1): RollingFileLogger =
   ## Creates a new rolling file logger. Once a file reaches ``maxLines`` lines
   ## a new log file will be started and the old will be renamed.
+  ## Use ``bufSize`` as size of the output buffer when writing the file
+  ## (-1: use system defaults, 0: unbuffered, >0: fixed buffer size).
   new(result)
   result.levelThreshold = levelThreshold
   result.fmtStr = fmtStr

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -82,6 +82,7 @@ type
     baseName: string # initial filename
     baseMode: FileMode # initial file mode
     logFiles: int # how many log files already created, e.g. basename.1, basename.2...
+    bufSize: int # size of output buffer (-1: automatic, 0: unbuffered, >0: fixed buffer size)
 
 {.deprecated: [TLevel: Level, PLogger: Logger, PConsoleLogger: ConsoleLogger,
     PFileLogger: FileLogger, PRollingFileLogger: RollingFileLogger].}
@@ -148,11 +149,12 @@ proc newConsoleLogger*(levelThreshold = lvlAll, fmtStr = defaultFmtStr): Console
 proc newFileLogger*(filename = defaultFilename(),
                     mode: FileMode = fmAppend,
                     levelThreshold = lvlAll,
-                    fmtStr = defaultFmtStr): FileLogger =
+                    fmtStr = defaultFmtStr,
+                    bufSize: int = -1): FileLogger =
   ## Creates a new file logger. This logger logs to a file.
   new(result)
   result.levelThreshold = levelThreshold
-  result.f = open(filename, mode)
+  result.f = open(filename, mode, bufSize = bufSize)
   result.fmtStr = fmtStr
 
 # ------
@@ -181,14 +183,16 @@ proc newRollingFileLogger*(filename = defaultFilename(),
                            mode: FileMode = fmReadWrite,
                            levelThreshold = lvlAll,
                            fmtStr = defaultFmtStr,
-                           maxLines = 1000): RollingFileLogger =
+                           maxLines = 1000,
+                           bufSize: int = -1): RollingFileLogger =
   ## Creates a new rolling file logger. Once a file reaches ``maxLines`` lines
   ## a new log file will be started and the old will be renamed.
   new(result)
   result.levelThreshold = levelThreshold
   result.fmtStr = fmtStr
   result.maxLines = maxLines
-  result.f = open(filename, mode)
+  result.bufSize = bufSize
+  result.f = open(filename, mode, bufSize=result.bufSize)
   result.curLine = 0
   result.baseName = filename
   result.baseMode = mode
@@ -215,7 +219,7 @@ method log*(logger: RollingFileLogger, level: Level,
       rotate(logger)
       logger.logFiles.inc
       logger.curLine = 0
-      logger.f = open(logger.baseName, logger.baseMode)
+      logger.f = open(logger.baseName, logger.baseMode, bufSize = logger.bufSize)
 
     writeln(logger.f, LevelNames[level], " ",substituteLog(logger.fmtStr), frmt % args)
     logger.curLine.inc


### PR DESCRIPTION
newFileLogger and newRollingFileLogger have a new bufSize parameter that
is used in open(). The default value -1 has the same behavior as before.
Use 0 for unbuffered output to log file.