### PR TITLE
Fixup: Reverted TZipFileStream name change

### DIFF
--- a/lib/impure/zipfiles.nim
+++ b/lib/impure/zipfiles.nim
@@ -114,7 +114,7 @@ type
     atEnd: bool
 
   PZipFileStream* =
-    ref ZipFileStream ## a reader stream of a file within a zip archive
+    ref TZipFileStream ## a reader stream of a file within a zip archive
 
 proc fsClose(s: Stream) = zip_fclose(PZipFileStream(s).f)
 proc fsAtEnd(s: Stream): bool = PZipFileStream(s).atEnd


### PR DESCRIPTION
This fixes broken b0469c11e334e96cebe53cbe804b6a877831c85a that incompletely
reverted TZipFileStream name change

Didn't create branch as it is fixup.