### PR TITLE
Note about deprecation in generics.txt

### DIFF
--- a/doc/manual/generics.txt
+++ b/doc/manual/generics.txt
@@ -164,11 +164,13 @@ Alternatively, the ``distinct`` type modifier can be applied to the type class
 to allow each param matching the type class to bind to a different type.
 
 If a proc param doesn't have a type specified, Nim will use the
-``distinct auto`` type class (also known as ``any``):
+``distinct auto`` type class (also known as ``any``). Note this behavior is 
+deprecated for procs; templates, however, support them:
 
 .. code-block:: nim
   # allow any combination of param types
-  proc concat(a, b): string = $a & $b
+  proc concat(a, b): string = $a & $b # deprecated
+  proc concat(a, b: any): string = $a & $b # preferred
 
 Procs written with the implicitly generic style will often need to refer to the
 type parameters of the matched generic type. They can be easily accessed using


### PR DESCRIPTION
I'm happy to change the wording or anything. It does seem like an important thing to mention, though. It might be better not to even mention typeless procs so as not to encourage bad behavior.