### PR TITLE
Fixes #2886 (moves compiler function into the compiler)

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -948,6 +948,9 @@ proc add*(father, son: PNode) =
 proc `[]`*(n: PNode, i: int): PNode {.inline.} =
   result = n.sons[i]
 
+template `-|`*(b, s: expr): expr =
+  (if b >= 0: b else: s.len + b)
+
 # son access operators with support for negative indices
 template `{}`*(n: PNode, i: int): expr = n[i -| n]
 template `{}=`*(n: PNode, i: int, s: PNode): stmt =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2859,9 +2859,6 @@ proc `/`*(x, y: int): float {.inline, noSideEffect.} =
   ## integer division that results in a float.
   result = toFloat(x) / toFloat(y)
 
-template `-|`*(b, s: expr): expr =
-  (if b >= 0: b else: s.len + b)
-
 template spliceImpl(s, a, L, b: expr): stmt {.immediate.} =
   # make room for additional elements or cut:
   var slen = s.len


### PR DESCRIPTION
`-|` not used in standard library, so it is moved to ast.nim, where it's used. Fixes #2886 